### PR TITLE
Make qBraid API timeout configurable + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ uses: qBraid/upload-course-api@v0.1.0-beta
 - Updated test infrastructure to use pytest exclusively
 - Improved test organization with markers and shared fixtures
 - Enhanced Makefile with coverage commands
+- Increased default qBraid API request timeout from 5s to 30s for course deployment steps
+- Added configurable request timeout via `QBRAID_REQUEST_TIMEOUT_SECONDS` (positive integer)
+- Documented timeout/environment configuration in `README.md` and `WORKFLOW_GUIDE.md`
 
 ## [Unreleased]
 ### Planned for v1.0.0 (Stable)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ jobs:
 | `article-type` | Type of article to create (`course` or `blog`) | No | `course` |
 | `force-duplicate-questions` | Whether to force upload duplicate questions (`true` or `false`) | No | `false` |
 
+## Optional Environment Variables
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `QBRAID_API_BASE_URL` | Override the qBraid API base URL (useful for local/dev testing) | `https://api-staging.qbraid.com/api/v1` |
+| `QBRAID_REQUEST_TIMEOUT_SECONDS` | HTTP request timeout for qBraid API calls | `30` |
+
 ## Outputs
 
 | Output | Description |
@@ -125,7 +132,8 @@ This action implements several security measures:
 
 ### Configuration Security
 - API base URL can be overridden via `QBRAID_API_BASE_URL` environment variable for testing
-- Default production URL: `https://api.qbraid.com`
+- Default API base URL: `https://api-staging.qbraid.com/api/v1`
+- Request timeout can be configured via `QBRAID_REQUEST_TIMEOUT_SECONDS` (must be a positive integer)
 - Timeouts on all API requests prevent hanging operations
 
 ### Best Practices

--- a/WORKFLOW_GUIDE.md
+++ b/WORKFLOW_GUIDE.md
@@ -166,6 +166,23 @@ The workflow validates image references in markdown cells. Images can be referen
 ### Upload fails
 - Ensure your API key has permissions to upload files.
 - Check if the file paths contain special characters that might cause issues.
+- If the API is slow, increase `QBRAID_REQUEST_TIMEOUT_SECONDS` in your workflow `env` (default: `30`).
+
+Example:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      QBRAID_REQUEST_TIMEOUT_SECONDS: "60"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: qBraid/upload-course-api@v0.1.0-beta
+        with:
+          api-key: ${{ secrets.QBRAID_API_KEY }}
+          repo-read-token: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ## Support
 

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -22,6 +22,20 @@ def setup_logging(name: str) -> logging.Logger:
     return logger
 
 
+def _get_env_int(name: str, default: int) -> int:
+    """Parse a positive integer from env vars, falling back to default."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+        if parsed > 0:
+            return parsed
+    except ValueError:
+        pass
+    return default
+
+
 @dataclass(frozen=True)
 class Config:
     """Application configuration constants."""
@@ -30,7 +44,7 @@ class Config:
     DEFAULT_API_BASE_URL: str = "https://api-staging.qbraid.com/api/v1"
     # DEFAULT_API_BASE_URL: str = "https://ad78f4d43151.ngrok-free.app/app1/api/v1"
     API_BASE_URL: str = os.getenv("QBRAID_API_BASE_URL", DEFAULT_API_BASE_URL)
-    REQUEST_TIMEOUT_SECONDS: int = 5
+    REQUEST_TIMEOUT_SECONDS: int = _get_env_int("QBRAID_REQUEST_TIMEOUT_SECONDS", 30)
     MAX_POLL_ATTEMPTS: int = 10
     POLL_INTERVAL_SECONDS: int = 15
     MAX_CONSECUTIVE_ERRORS: int = 5

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -18,6 +18,7 @@ def test_config_default():
             import common
 
         assert common.Config.API_BASE_URL == "https://api-staging.qbraid.com/api/v1"
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30
 
 
 @pytest.mark.unit
@@ -33,3 +34,23 @@ def test_config_env_override():
             import common
 
         assert common.Config.API_BASE_URL == test_url
+
+
+@pytest.mark.unit
+def test_config_timeout_env_override():
+    """Test timeout env var override and fallback behavior."""
+    with mock.patch.dict(os.environ, {"QBRAID_REQUEST_TIMEOUT_SECONDS": "60"}):
+        if "common" in sys.modules:
+            import common
+
+            importlib.reload(common)
+        else:
+            import common
+
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 60
+
+    with mock.patch.dict(os.environ, {"QBRAID_REQUEST_TIMEOUT_SECONDS": "invalid"}):
+        import common
+
+        importlib.reload(common)
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30


### PR DESCRIPTION
## What
- Make API request timeout configurable via QBRAID_REQUEST_TIMEOUT_SECONDS
- Increase default timeout from 5s to 30s
- Add unit tests for default, env override, and invalid value fallback
- Document timeout env var in README and WORKFLOW_GUIDE

## Why
Some staging API create-course requests exceed 5 seconds and were failing with read timeouts.

## Validation
- uv run pytest test/unit/test_config.py -q