### PR TITLE
Make polling behavior configurable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,16 @@ jobs:
             coverage.xml
             htmlcov
 
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.11'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          name: upload-course-api
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   action-metadata:
     name: Actionlint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ uses: qBraid/upload-course-api@v0.1.0-beta
 - Added configurable polling controls via environment variables:
   `QBRAID_MAX_POLL_ATTEMPTS`, `QBRAID_POLL_INTERVAL_SECONDS`,
   and `QBRAID_MAX_CONSECUTIVE_ERRORS`
+- Updated default `QBRAID_MAX_POLL_ATTEMPTS` to `15`
 - Documented polling environment configuration in `README.md` and `WORKFLOW_GUIDE.md`
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ uses: qBraid/upload-course-api@v0.1.0-beta
 - Updated test infrastructure to use pytest exclusively
 - Improved test organization with markers and shared fixtures
 - Enhanced Makefile with coverage commands
+- Added configurable polling controls via environment variables:
+  `QBRAID_MAX_POLL_ATTEMPTS`, `QBRAID_POLL_INTERVAL_SECONDS`,
+  and `QBRAID_MAX_CONSECUTIVE_ERRORS`
+- Documented polling environment configuration in `README.md` and `WORKFLOW_GUIDE.md`
 
 ## [Unreleased]
 ### Planned for v1.0.0 (Stable)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ jobs:
 | `article-type` | Type of article to create (`course` or `blog`) | No | `course` |
 | `force-duplicate-questions` | Whether to force upload duplicate questions (`true` or `false`) | No | `false` |
 
+## Optional Environment Variables
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `QBRAID_API_BASE_URL` | Override the qBraid API base URL (useful for local/dev testing) | `https://api-staging.qbraid.com/api/v1` |
+| `QBRAID_MAX_POLL_ATTEMPTS` | Maximum polling attempts before timing out | `10` |
+| `QBRAID_POLL_INTERVAL_SECONDS` | Seconds to wait between polling attempts | `15` |
+| `QBRAID_MAX_CONSECUTIVE_ERRORS` | Maximum consecutive polling request errors before failing | `5` |
+
 ## Outputs
 
 | Output | Description |
@@ -126,6 +135,7 @@ This action implements several security measures:
 ### Configuration Security
 - API base URL can be overridden via `QBRAID_API_BASE_URL` environment variable for testing
 - Default production URL: `https://api.qbraid.com`
+- Polling behavior can be tuned using `QBRAID_MAX_POLL_ATTEMPTS`, `QBRAID_POLL_INTERVAL_SECONDS`, and `QBRAID_MAX_CONSECUTIVE_ERRORS`
 - Timeouts on all API requests prevent hanging operations
 
 ### Best Practices

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
 | Variable | Description | Default |
 | :--- | :--- | :--- |
 | `QBRAID_API_BASE_URL` | Override the qBraid API base URL (useful for local/dev testing) | `https://api-staging.qbraid.com/api/v1` |
-| `QBRAID_MAX_POLL_ATTEMPTS` | Maximum polling attempts before timing out | `10` |
+| `QBRAID_MAX_POLL_ATTEMPTS` | Maximum polling attempts before timing out | `15` |
 | `QBRAID_POLL_INTERVAL_SECONDS` | Seconds to wait between polling attempts | `15` |
 | `QBRAID_MAX_CONSECUTIVE_ERRORS` | Maximum consecutive polling request errors before failing | `5` |
 

--- a/WORKFLOW_GUIDE.md
+++ b/WORKFLOW_GUIDE.md
@@ -167,6 +167,27 @@ The workflow validates image references in markdown cells. Images can be referen
 - Ensure your API key has permissions to upload files.
 - Check if the file paths contain special characters that might cause issues.
 
+### Polling times out
+- Increase polling controls in workflow `env` if processing takes longer in staging.
+
+Example:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      QBRAID_MAX_POLL_ATTEMPTS: "20"
+      QBRAID_POLL_INTERVAL_SECONDS: "30"
+      QBRAID_MAX_CONSECUTIVE_ERRORS: "7"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: qBraid/upload-course-api@v0.1.0-beta
+        with:
+          api-key: ${{ secrets.QBRAID_API_KEY }}
+          repo-read-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Support
 
 For issues related to:

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -22,6 +22,20 @@ def setup_logging(name: str) -> logging.Logger:
     return logger
 
 
+def _get_env_int(name: str, default: int) -> int:
+    """Parse a positive integer from env vars, falling back to default."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+        if parsed > 0:
+            return parsed
+    except ValueError:
+        pass
+    return default
+
+
 @dataclass(frozen=True)
 class Config:
     """Application configuration constants."""
@@ -31,9 +45,9 @@ class Config:
     # DEFAULT_API_BASE_URL: str = "https://ad78f4d43151.ngrok-free.app/app1/api/v1"
     API_BASE_URL: str = os.getenv("QBRAID_API_BASE_URL", DEFAULT_API_BASE_URL)
     REQUEST_TIMEOUT_SECONDS: int = 5
-    MAX_POLL_ATTEMPTS: int = 10
-    POLL_INTERVAL_SECONDS: int = 15
-    MAX_CONSECUTIVE_ERRORS: int = 5
+    MAX_POLL_ATTEMPTS: int = _get_env_int("QBRAID_MAX_POLL_ATTEMPTS", 10)
+    POLL_INTERVAL_SECONDS: int = _get_env_int("QBRAID_POLL_INTERVAL_SECONDS", 15)
+    MAX_CONSECUTIVE_ERRORS: int = _get_env_int("QBRAID_MAX_CONSECUTIVE_ERRORS", 5)
 
     # Validation Configuration
     MAX_NOTEBOOK_SIZE_MB: int = 5

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -45,7 +45,7 @@ class Config:
     # DEFAULT_API_BASE_URL: str = "https://ad78f4d43151.ngrok-free.app/app1/api/v1"
     API_BASE_URL: str = os.getenv("QBRAID_API_BASE_URL", DEFAULT_API_BASE_URL)
     REQUEST_TIMEOUT_SECONDS: int = 5
-    MAX_POLL_ATTEMPTS: int = _get_env_int("QBRAID_MAX_POLL_ATTEMPTS", 10)
+    MAX_POLL_ATTEMPTS: int = _get_env_int("QBRAID_MAX_POLL_ATTEMPTS", 15)
     POLL_INTERVAL_SECONDS: int = _get_env_int("QBRAID_POLL_INTERVAL_SECONDS", 15)
     MAX_CONSECUTIVE_ERRORS: int = _get_env_int("QBRAID_MAX_CONSECUTIVE_ERRORS", 5)
 

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -44,7 +44,7 @@ class Config:
     DEFAULT_API_BASE_URL: str = "https://api-staging.qbraid.com/api/v1"
     # DEFAULT_API_BASE_URL: str = "https://ad78f4d43151.ngrok-free.app/app1/api/v1"
     API_BASE_URL: str = os.getenv("QBRAID_API_BASE_URL", DEFAULT_API_BASE_URL)
-    REQUEST_TIMEOUT_SECONDS: int = 5
+    REQUEST_TIMEOUT_SECONDS: int = _get_env_int("QBRAID_REQUEST_TIMEOUT_SECONDS", 30)
     MAX_POLL_ATTEMPTS: int = _get_env_int("QBRAID_MAX_POLL_ATTEMPTS", 15)
     POLL_INTERVAL_SECONDS: int = _get_env_int("QBRAID_POLL_INTERVAL_SECONDS", 15)
     MAX_CONSECUTIVE_ERRORS: int = _get_env_int("QBRAID_MAX_CONSECUTIVE_ERRORS", 5)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -18,6 +18,9 @@ def test_config_default():
             import common
 
         assert common.Config.API_BASE_URL == "https://api-staging.qbraid.com/api/v1"
+        assert common.Config.MAX_POLL_ATTEMPTS == 10
+        assert common.Config.POLL_INTERVAL_SECONDS == 15
+        assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
 
 
 @pytest.mark.unit
@@ -33,3 +36,41 @@ def test_config_env_override():
             import common
 
         assert common.Config.API_BASE_URL == test_url
+
+
+@pytest.mark.unit
+def test_config_polling_env_overrides():
+    """Test polling env var overrides and fallback behavior."""
+    with mock.patch.dict(
+        os.environ,
+        {
+            "QBRAID_MAX_POLL_ATTEMPTS": "20",
+            "QBRAID_POLL_INTERVAL_SECONDS": "30",
+            "QBRAID_MAX_CONSECUTIVE_ERRORS": "7",
+        },
+    ):
+        if "common" in sys.modules:
+            import common
+
+            importlib.reload(common)
+        else:
+            import common
+
+        assert common.Config.MAX_POLL_ATTEMPTS == 20
+        assert common.Config.POLL_INTERVAL_SECONDS == 30
+        assert common.Config.MAX_CONSECUTIVE_ERRORS == 7
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "QBRAID_MAX_POLL_ATTEMPTS": "invalid",
+            "QBRAID_POLL_INTERVAL_SECONDS": "-1",
+            "QBRAID_MAX_CONSECUTIVE_ERRORS": "0",
+        },
+    ):
+        import common
+
+        importlib.reload(common)
+        assert common.Config.MAX_POLL_ATTEMPTS == 10
+        assert common.Config.POLL_INTERVAL_SECONDS == 15
+        assert common.Config.MAX_CONSECUTIVE_ERRORS == 5

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -21,7 +21,7 @@ def test_config_default():
         assert common.Config.MAX_POLL_ATTEMPTS == 15
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
 
 
 @pytest.mark.unit
@@ -50,9 +50,6 @@ def test_config_polling_env_overrides():
             "QBRAID_MAX_CONSECUTIVE_ERRORS": "7",
         },
     ):
-def test_config_timeout_env_override():
-    """Test timeout env var override and fallback behavior."""
-    with mock.patch.dict(os.environ, {"QBRAID_REQUEST_TIMEOUT_SECONDS": "60"}):
         if "common" in sys.modules:
             import common
 
@@ -63,6 +60,7 @@ def test_config_timeout_env_override():
         assert common.Config.MAX_POLL_ATTEMPTS == 20
         assert common.Config.POLL_INTERVAL_SECONDS == 30
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 7
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
 
     with mock.patch.dict(
         os.environ,
@@ -78,10 +76,24 @@ def test_config_timeout_env_override():
         assert common.Config.MAX_POLL_ATTEMPTS == 15
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 60
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
+
+
+@pytest.mark.unit
+def test_config_timeout_env_override():
+    """Test timeout remains fixed even when env var is set."""
+    with mock.patch.dict(os.environ, {"QBRAID_REQUEST_TIMEOUT_SECONDS": "60"}):
+        if "common" in sys.modules:
+            import common
+
+            importlib.reload(common)
+        else:
+            import common
+
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
 
     with mock.patch.dict(os.environ, {"QBRAID_REQUEST_TIMEOUT_SECONDS": "invalid"}):
         import common
 
         importlib.reload(common)
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -18,7 +18,7 @@ def test_config_default():
             import common
 
         assert common.Config.API_BASE_URL == "https://api-staging.qbraid.com/api/v1"
-        assert common.Config.MAX_POLL_ATTEMPTS == 10
+        assert common.Config.MAX_POLL_ATTEMPTS == 15
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
 
@@ -71,6 +71,6 @@ def test_config_polling_env_overrides():
         import common
 
         importlib.reload(common)
-        assert common.Config.MAX_POLL_ATTEMPTS == 10
+        assert common.Config.MAX_POLL_ATTEMPTS == 15
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -21,7 +21,7 @@ def test_config_default():
         assert common.Config.MAX_POLL_ATTEMPTS == 15
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30
 
 
 @pytest.mark.unit
@@ -60,7 +60,7 @@ def test_config_polling_env_overrides():
         assert common.Config.MAX_POLL_ATTEMPTS == 20
         assert common.Config.POLL_INTERVAL_SECONDS == 30
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 7
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30
 
     with mock.patch.dict(
         os.environ,
@@ -76,12 +76,12 @@ def test_config_polling_env_overrides():
         assert common.Config.MAX_POLL_ATTEMPTS == 15
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30
 
 
 @pytest.mark.unit
 def test_config_timeout_env_override():
-    """Test timeout remains fixed even when env var is set."""
+    """Test timeout env var override and fallback behavior."""
     with mock.patch.dict(os.environ, {"QBRAID_REQUEST_TIMEOUT_SECONDS": "60"}):
         if "common" in sys.modules:
             import common
@@ -90,10 +90,10 @@ def test_config_timeout_env_override():
         else:
             import common
 
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 60
 
     with mock.patch.dict(os.environ, {"QBRAID_REQUEST_TIMEOUT_SECONDS": "invalid"}):
         import common
 
         importlib.reload(common)
-        assert common.Config.REQUEST_TIMEOUT_SECONDS == 5
+        assert common.Config.REQUEST_TIMEOUT_SECONDS == 30

--- a/uv.lock
+++ b/uv.lock
@@ -10,9 +10,9 @@ resolution-markers = [
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2026-05-20T21:33:25.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2026-05-20T21:33:24.1Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -387,9 +387,9 @@ dependencies = [
     { name = "jupyter-core" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2026-04-04T11:20:37.371Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2026-04-04T11:20:34.895Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
 ]
 
 [[package]]
@@ -668,9 +668,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2026-03-29T03:54:29.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2026-03-29T03:54:27.64Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
 ]
 
 [[package]]
@@ -883,9 +883,9 @@ wheels = [
 name = "traitlets"
 version = "5.14.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2026-04-19T11:11:49.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2026-04-19T11:11:46.763Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -911,7 +911,7 @@ wheels = [
 
 [[package]]
 name = "upload-action-repo"
-version = "0.1.0"
+version = "0.1.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "nbformat" },


### PR DESCRIPTION
## What
- Make polling configuration environment-driven
- Add QBRAID_MAX_POLL_ATTEMPTS (default 10)
- Add QBRAID_POLL_INTERVAL_SECONDS (default 15)
- Add QBRAID_MAX_CONSECUTIVE_ERRORS (default 5)
- Add config tests for defaults, overrides, and invalid fallback
- Document new env vars in README and WORKFLOW_GUIDE
- Update CHANGELOG

## Why
Staging processing duration varies, so fixed polling settings can timeout too early.

## Validation
- uv run pytest test/unit/test_config.py test/unit/test_poll_files_progress.py -q