### PR TITLE
Make polling configurable in the action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ uses: qBraid/upload-course-api@v0.1.0-beta
 ## [Unreleased]
 
 ### Added
+- Action inputs to configure polling limits (`max-poll-attempts`, `poll-interval-seconds`, `max-consecutive-errors`)
 - Comprehensive pytest testing infrastructure with unit and E2E tests
 - Test markers for easy filtering (`@pytest.mark.unit`, `@pytest.mark.e2e`)
 - Shared test fixtures in `test/conftest.py` for mocking and GitHub Actions simulation
@@ -40,6 +41,7 @@ uses: qBraid/upload-course-api@v0.1.0-beta
 - Typos configuration file to ignore generated artifacts and allow project-specific terms (`qbraid`, `qbook`)
 
 ### Changed
+- Increased default polling attempts to 20 (from 10)
 - Updated test infrastructure to use pytest exclusively
 - Improved test organization with markers and shared fixtures
 - Enhanced Makefile with coverage commands

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ jobs:
 | `course-json-path` | Path to `course.json` file | No | `course.json` |
 | `article-type` | Type of article to create (`course` or `blog`) | No | `course` |
 | `force-duplicate-questions` | Whether to force upload duplicate questions (`true` or `false`) | No | `false` |
+| `max-poll-attempts` | Maximum polling attempts before timing out | No | `20` |
+| `poll-interval-seconds` | Seconds to wait between polling attempts | No | `15` |
+| `max-consecutive-errors` | Maximum consecutive polling errors before failing | No | `5` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,18 @@ inputs:
     description: 'Whether to create a draft course (true or false)'
     required: false
     default: 'false'
+  max-poll-attempts:
+    description: 'Maximum polling attempts before timing out'
+    required: false
+    default: '20'
+  poll-interval-seconds:
+    description: 'Seconds to wait between polling attempts'
+    required: false
+    default: '15'
+  max-consecutive-errors:
+    description: 'Maximum consecutive polling errors before failing'
+    required: false
+    default: '5'
   mode:
     description: 'Operation mode: "create" or "update"'
     required: false
@@ -123,6 +135,10 @@ runs:
     - name: Stage 6 - Poll status end point for completion
       id: poll-status
       shell: bash
+      env:
+        QBRAID_MAX_POLL_ATTEMPTS: ${{ inputs.max-poll-attempts }}
+        QBRAID_POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}
+        QBRAID_MAX_CONSECUTIVE_ERRORS: ${{ inputs.max-consecutive-errors }}
       run: |
         COURSE_ID="${{ steps.create-course.outputs.course_custom_id }}${{ steps.update-course.outputs.course_custom_id }}"
         python ${{ github.action_path }}/src/scripts/poll_files_progress.py '${{ inputs.api-key }}' "$COURSE_ID"

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -44,8 +44,8 @@ class Config:
     DEFAULT_API_BASE_URL: str = "https://api-staging.qbraid.com/api/v1"
     # DEFAULT_API_BASE_URL: str = "https://ad78f4d43151.ngrok-free.app/app1/api/v1"
     API_BASE_URL: str = os.getenv("QBRAID_API_BASE_URL", DEFAULT_API_BASE_URL)
-    MAX_POLL_ATTEMPTS: int = _get_env_int("QBRAID_MAX_POLL_ATTEMPTS", 20)
     REQUEST_TIMEOUT_SECONDS: int = _get_env_int("QBRAID_REQUEST_TIMEOUT_SECONDS", 30)
+    MAX_POLL_ATTEMPTS: int = _get_env_int("QBRAID_MAX_POLL_ATTEMPTS", 20)
     POLL_INTERVAL_SECONDS: int = _get_env_int("QBRAID_POLL_INTERVAL_SECONDS", 15)
     MAX_CONSECUTIVE_ERRORS: int = _get_env_int("QBRAID_MAX_CONSECUTIVE_ERRORS", 5)
 

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -22,6 +22,20 @@ def setup_logging(name: str) -> logging.Logger:
     return logger
 
 
+def _get_env_int(name: str, default: int) -> int:
+    """Parse a positive integer from env vars, falling back to default."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+        if parsed > 0:
+            return parsed
+    except ValueError:
+        pass
+    return default
+
+
 @dataclass(frozen=True)
 class Config:
     """Application configuration constants."""
@@ -30,10 +44,10 @@ class Config:
     DEFAULT_API_BASE_URL: str = "https://api-staging.qbraid.com/api/v1"
     # DEFAULT_API_BASE_URL: str = "https://ad78f4d43151.ngrok-free.app/app1/api/v1"
     API_BASE_URL: str = os.getenv("QBRAID_API_BASE_URL", DEFAULT_API_BASE_URL)
-    REQUEST_TIMEOUT_SECONDS: int = 5
-    MAX_POLL_ATTEMPTS: int = 10
-    POLL_INTERVAL_SECONDS: int = 15
-    MAX_CONSECUTIVE_ERRORS: int = 5
+    REQUEST_TIMEOUT_SECONDS: int = _get_env_int("QBRAID_REQUEST_TIMEOUT_SECONDS", 5)
+    MAX_POLL_ATTEMPTS: int = _get_env_int("QBRAID_MAX_POLL_ATTEMPTS", 20)
+    POLL_INTERVAL_SECONDS: int = _get_env_int("QBRAID_POLL_INTERVAL_SECONDS", 15)
+    MAX_CONSECUTIVE_ERRORS: int = _get_env_int("QBRAID_MAX_CONSECUTIVE_ERRORS", 5)
 
     # Validation Configuration
     MAX_NOTEBOOK_SIZE_MB: int = 5

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -18,7 +18,7 @@ def test_config_default():
             import common
 
         assert common.Config.API_BASE_URL == "https://api-staging.qbraid.com/api/v1"
-        assert common.Config.MAX_POLL_ATTEMPTS == 15
+        assert common.Config.MAX_POLL_ATTEMPTS == 20
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
         assert common.Config.REQUEST_TIMEOUT_SECONDS == 30
@@ -73,7 +73,7 @@ def test_config_polling_env_overrides():
         import common
 
         importlib.reload(common)
-        assert common.Config.MAX_POLL_ATTEMPTS == 15
+        assert common.Config.MAX_POLL_ATTEMPTS == 20
         assert common.Config.POLL_INTERVAL_SECONDS == 15
         assert common.Config.MAX_CONSECUTIVE_ERRORS == 5
         assert common.Config.REQUEST_TIMEOUT_SECONDS == 30


### PR DESCRIPTION
## Summary
- double default polling attempts to 20 and read polling settings from env
- expose polling settings as action inputs and pass them to the poll step
- document new inputs in README and update CHANGELOG\n\n## Testing
