### PR TITLE
feat: add deploy-kernel action and Dockerfile validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ uses: qBraid/upload-course-action@v0.1.0-beta
 - Fixed JSend response parsing in deploy and polling scripts to support `{status, data}` envelope format
 - Added guard in `action.yml` to fail early with a clear error when `course_custom_id` is empty after create/update step
 - Replaced silent `pass` with warning logs when API response parsing fails
+- Failed kernel deployment polling immediately on terminal API errors instead of retrying until timeout
+- Made the deploy-kernel wrapper reuse the shared Dockerfile validator implementation
+
+### Changed
+- Treat active pre-existing kernels as a successful deploy outcome for rerun-safe custom kernel workflows
 
 ### Added
 - Unit tests for JSend response handling in course creation and polling

--- a/deploy-kernel/action.yml
+++ b/deploy-kernel/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'qBraid API base URL'
     required: false
     default: 'https://api-v2.qbraid.com/api/v1'
+  timeout-seconds:
+    description: 'Maximum time to wait for deployment to finish'
+    required: false
+    default: '1800'
 
 outputs:
   kernel-name:
@@ -68,12 +72,16 @@ runs:
     - name: Deploy kernel
       id: deploy-kernel
       shell: bash
+      env:
+        QBRAID_API_KEY: ${{ inputs.api-key }}
+        QBRAID_DEPLOY_TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
       run: |
+        echo "::add-mask::$QBRAID_API_KEY"
         python ${{ github.action_path }}/src/scripts/deploy_kernel.py \
-          --api-key "${{ inputs.api-key }}" \
           --dockerfile-path "${{ inputs.dockerfile-path }}" \
           --kernel-name "${{ inputs.kernel-name }}" \
           --language "${{ inputs.language }}" \
           --display-name "${{ inputs.display-name }}" \
           --context-dir "${{ inputs.context-dir }}" \
-          --api-base-url "${{ inputs.api-base-url }}"
+          --api-base-url "${{ inputs.api-base-url }}" \
+          --timeout-seconds "${{ inputs.timeout-seconds }}"

--- a/deploy-kernel/action.yml
+++ b/deploy-kernel/action.yml
@@ -35,6 +35,15 @@ inputs:
     description: 'Maximum time to wait for deployment to finish'
     required: false
     default: '1800'
+  cpu:
+    description: 'Default CPU per kernel pod (e.g. "2", "3", "2500m"). Server enforces a minimum of 2 cores and a maximum of 4. Omit to leave the kernel''s existing default unchanged.'
+    required: false
+  memory:
+    description: 'Default memory request per kernel pod (e.g. "4Gi", "8Gi"). Server enforces a minimum of 4 GiB and a maximum of 8 GiB. Omit to leave the kernel''s existing default unchanged.'
+    required: false
+  memory-limit:
+    description: 'Default memory limit per kernel pod (must be >= memory). Same units and ceiling as memory. Omit to leave the kernel''s existing default unchanged.'
+    required: false
 
 outputs:
   kernel-name:
@@ -85,4 +94,7 @@ runs:
           --display-name "${{ inputs.display-name }}" \
           --context-dir "${{ inputs.context-dir }}" \
           --api-base-url "${{ inputs.api-base-url }}" \
-          --timeout-seconds "${{ inputs.timeout-seconds }}"
+          --timeout-seconds "${{ inputs.timeout-seconds }}" \
+          --cpu "${{ inputs.cpu }}" \
+          --memory "${{ inputs.memory }}" \
+          --memory-limit "${{ inputs.memory-limit }}"

--- a/deploy-kernel/action.yml
+++ b/deploy-kernel/action.yml
@@ -67,7 +67,8 @@ runs:
       shell: bash
       run: |
         python ${{ github.action_path }}/src/scripts/validate_dockerfile.py \
-          "${{ inputs.dockerfile-path }}"
+          "${{ inputs.dockerfile-path }}" \
+          "${{ inputs.context-dir }}"
 
     - name: Deploy kernel
       id: deploy-kernel

--- a/deploy-kernel/action.yml
+++ b/deploy-kernel/action.yml
@@ -35,12 +35,16 @@ inputs:
 outputs:
   kernel-name:
     description: 'The deployed kernel name'
+    value: ${{ steps.deploy-kernel.outputs.kernel-name }}
   image-uri:
     description: 'The Artifact Registry image URI'
+    value: ${{ steps.deploy-kernel.outputs.image-uri }}
   status:
     description: 'Deployment status (active, failed)'
+    value: ${{ steps.deploy-kernel.outputs.status }}
   build-id:
     description: 'Cloud Build ID'
+    value: ${{ steps.deploy-kernel.outputs.build-id }}
 
 runs:
   using: 'composite'
@@ -62,6 +66,7 @@ runs:
           "${{ inputs.dockerfile-path }}"
 
     - name: Deploy kernel
+      id: deploy-kernel
       shell: bash
       run: |
         python ${{ github.action_path }}/src/scripts/deploy_kernel.py \

--- a/deploy-kernel/action.yml
+++ b/deploy-kernel/action.yml
@@ -40,7 +40,7 @@ outputs:
     description: 'The Artifact Registry image URI'
     value: ${{ steps.deploy-kernel.outputs.image-uri }}
   status:
-    description: 'Deployment status (active, failed)'
+    description: 'Deployment status (active, failed, timeout)'
     value: ${{ steps.deploy-kernel.outputs.status }}
   build-id:
     description: 'Cloud Build ID'
@@ -57,7 +57,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        pip install -q requests qbraid-core tenacity
+        python -m pip install -q -r "${{ github.action_path }}/requirements.txt"
 
     - name: Validate Dockerfile
       shell: bash

--- a/deploy-kernel/action.yml
+++ b/deploy-kernel/action.yml
@@ -1,0 +1,74 @@
+name: 'Deploy Custom Kernel to qBraid'
+description: 'Validates and deploys a custom Jupyter kernel image to qBraid qBook'
+author: 'qBraid'
+
+branding:
+  icon: 'cpu'
+  color: 'purple'
+
+inputs:
+  api-key:
+    description: 'qBraid API key for authentication'
+    required: true
+  dockerfile-path:
+    description: 'Path to the kernel Dockerfile'
+    required: false
+    default: 'Dockerfile.kernel'
+  kernel-name:
+    description: 'Unique kernel name (lowercase alphanumeric + underscore, 3-64 chars)'
+    required: true
+  language:
+    description: 'Kernel language (python, cpp, julia, r, rust, go, javascript)'
+    required: true
+  display-name:
+    description: 'Human-readable display name for the kernel'
+    required: true
+  context-dir:
+    description: 'Directory containing additional build context files (requirements.txt, kernel.json, etc.)'
+    required: false
+    default: '.'
+  api-base-url:
+    description: 'qBraid API base URL'
+    required: false
+    default: 'https://api-v2.qbraid.com/api/v1'
+
+outputs:
+  kernel-name:
+    description: 'The deployed kernel name'
+  image-uri:
+    description: 'The Artifact Registry image URI'
+  status:
+    description: 'Deployment status (active, failed)'
+  build-id:
+    description: 'Cloud Build ID'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        pip install -q requests qbraid-core tenacity
+
+    - name: Validate Dockerfile
+      shell: bash
+      run: |
+        python ${{ github.action_path }}/src/scripts/validate_dockerfile.py \
+          "${{ inputs.dockerfile-path }}"
+
+    - name: Deploy kernel
+      shell: bash
+      run: |
+        python ${{ github.action_path }}/src/scripts/deploy_kernel.py \
+          --api-key "${{ inputs.api-key }}" \
+          --dockerfile-path "${{ inputs.dockerfile-path }}" \
+          --kernel-name "${{ inputs.kernel-name }}" \
+          --language "${{ inputs.language }}" \
+          --display-name "${{ inputs.display-name }}" \
+          --context-dir "${{ inputs.context-dir }}" \
+          --api-base-url "${{ inputs.api-base-url }}"

--- a/deploy-kernel/requirements.txt
+++ b/deploy-kernel/requirements.txt
@@ -1,3 +1,1 @@
 requests>=2.31.0
-qbraid-core>=0.1.0
-tenacity>=8.2.0

--- a/deploy-kernel/requirements.txt
+++ b/deploy-kernel/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31.0
+qbraid-core>=0.1.0
+tenacity>=8.2.0

--- a/deploy-kernel/src/scripts/context_files.py
+++ b/deploy-kernel/src/scripts/context_files.py
@@ -11,9 +11,7 @@ def _load_shared_context_files_module():
     repo_root = Path(__file__).resolve().parents[3]
     shared_path = repo_root / "src" / "scripts" / "context_files.py"
 
-    spec = importlib.util.spec_from_file_location(
-        "shared_context_files", shared_path
-    )
+    spec = importlib.util.spec_from_file_location("shared_context_files", shared_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load shared context_files from {shared_path}")
 

--- a/deploy-kernel/src/scripts/context_files.py
+++ b/deploy-kernel/src/scripts/context_files.py
@@ -1,0 +1,36 @@
+"""Delegate to the shared context-files helper (single source of truth)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_shared_context_files_module():
+    repo_root = Path(__file__).resolve().parents[3]
+    shared_path = repo_root / "src" / "scripts" / "context_files.py"
+
+    spec = importlib.util.spec_from_file_location(
+        "shared_context_files", shared_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load shared context_files from {shared_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(shared_path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+_shared = _load_shared_context_files_module()
+
+MAX_CONTEXT_FILE_BYTES = _shared.MAX_CONTEXT_FILE_BYTES
+SKIPPED_CONTEXT_FILES = _shared.SKIPPED_CONTEXT_FILES
+SKIPPED_CONTEXT_SUFFIXES = _shared.SKIPPED_CONTEXT_SUFFIXES
+SKIPPED_CONTEXT_SUBSTRINGS = _shared.SKIPPED_CONTEXT_SUBSTRINGS
+is_skipped_context_file = _shared.is_skipped_context_file
+list_context_files = _shared.list_context_files

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -10,6 +10,11 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import requests
+from validate_dockerfile import (
+    SUPPORTED_LANGUAGES,
+    extract_dockerfile_labels,
+    KERNEL_NAME_PATTERN,
+)
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
@@ -26,14 +31,45 @@ POLL_INTERVAL_SECONDS = 30
 REQUEST_TIMEOUT_SECONDS = 30
 KERNEL_ALREADY_EXISTS_CODE = "KERNEL_ALREADY_EXISTS"
 FATAL_POLL_STATUS_CODES = {400, 401, 403, 404}
+DEFAULT_TIMEOUT_SECONDS = 1800
+SKIPPED_CONTEXT_FILES = frozenset(
+    {
+        ".gitignore",
+        ".dockerignore",
+        ".env",
+        ".env.local",
+        ".env.production",
+        ".env.staging",
+        ".npmrc",
+        ".pypirc",
+        ".netrc",
+        "id_rsa",
+        "id_ed25519",
+        "credentials",
+    }
+)
+SKIPPED_CONTEXT_SUFFIXES = (".pem", ".key", ".p12", ".crt", ".kubeconfig")
+SKIPPED_CONTEXT_SUBSTRINGS = ("secret", "token", "password", "credential")
 
 
 def write_github_output(key: str, value: str) -> None:
-    """Write a key-value pair to GITHUB_OUTPUT."""
+    """Safely write a key-value pair to GITHUB_OUTPUT."""
     if "GITHUB_OUTPUT" not in os.environ:
         return
     try:
         output_file = os.environ["GITHUB_OUTPUT"]
+        if "\n" in value:
+            delimiter = f"GITHUB_OUTPUT_DELIMITER_{key.upper()}"
+            while delimiter in value:
+                delimiter = f"{delimiter}_ALT"
+            with open(output_file, "a") as f:
+                f.write(f"{key}<<{delimiter}\n")
+                f.write(value)
+                if not value.endswith("\n"):
+                    f.write("\n")
+                f.write(f"{delimiter}\n")
+            return
+
         with open(output_file, "a") as f:
             f.write(f"{key}={value}\n")
     except (IOError, OSError) as e:
@@ -83,27 +119,89 @@ def _collect_context_files(context_dir: Path, dockerfile_path: Path) -> Dict[str
         return context_files
 
     for item in context_dir.iterdir():
-        if item.is_file() and item != dockerfile_path and item.name != ".gitignore":
-            # Skip very large files (> 10MB)
-            if item.stat().st_size > 10 * 1024 * 1024:
-                logger.warning(
-                    f"Skipping large file: {item.name} ({item.stat().st_size} bytes)"
-                )
-                continue
-            context_files[item.name] = _encode_file(item)
-            logger.info(f"  Including context file: {item.name}")
+        if not item.is_file() or item == dockerfile_path:
+            continue
+
+        item_name = item.name
+        lowered_name = item_name.lower()
+        if (
+            item_name in SKIPPED_CONTEXT_FILES
+            or item_name.startswith(".")
+            or lowered_name.endswith(SKIPPED_CONTEXT_SUFFIXES)
+            or any(part in lowered_name for part in SKIPPED_CONTEXT_SUBSTRINGS)
+        ):
+            logger.info(f"  Skipping sensitive context file: {item_name}")
+            continue
+
+        # Skip very large files (> 10MB)
+        if item.stat().st_size > 10 * 1024 * 1024:
+            logger.warning(
+                f"Skipping large file: {item.name} ({item.stat().st_size} bytes)"
+            )
+            continue
+        context_files[item.name] = _encode_file(item)
+        logger.info(f"  Including context file: {item.name}")
 
     return context_files
 
 
+def _validate_deploy_inputs(kernel_name: str, language: str, display_name: str) -> None:
+    if not KERNEL_NAME_PATTERN.match(kernel_name):
+        logger.error(
+            "Invalid kernel name '%s'. Use lowercase letters, digits, and underscores (3-64 chars, starting with a letter).",
+            kernel_name,
+        )
+        sys.exit(1)
+
+    if language not in SUPPORTED_LANGUAGES:
+        logger.error(
+            "Unsupported kernel language '%s'. Supported values: %s",
+            language,
+            ", ".join(sorted(SUPPORTED_LANGUAGES)),
+        )
+        sys.exit(1)
+
+    if not display_name.strip():
+        logger.error("Display name must not be empty")
+        sys.exit(1)
+
+
+def _validate_dockerfile_labels(
+    dockerfile_content: str,
+    kernel_name: str,
+    language: str,
+    display_name: str,
+) -> None:
+    labels = extract_dockerfile_labels(dockerfile_content)
+    expected_labels = {
+        "qbraid.kernel.name": kernel_name,
+        "qbraid.kernel.language": language,
+        "qbraid.kernel.display_name": display_name,
+    }
+
+    for label_key, expected_value in expected_labels.items():
+        actual_value = labels.get(label_key)
+        if actual_value is None:
+            continue
+        if actual_value != expected_value:
+            logger.error(
+                "Dockerfile label %s=%r does not match action input %r",
+                label_key,
+                actual_value,
+                expected_value,
+            )
+            sys.exit(1)
+
+
 def deploy_kernel(
-    api_key: str,
     dockerfile_path: str,
     kernel_name: str,
     language: str,
     display_name: str,
     context_dir: str,
     api_base_url: str,
+    api_key: Optional[str] = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
 ) -> None:
     """Deploy a custom kernel to qBraid."""
     dockerfile = Path(dockerfile_path)
@@ -111,11 +209,22 @@ def deploy_kernel(
         logger.error(f"Dockerfile not found: {dockerfile}")
         sys.exit(1)
 
+    resolved_api_key = api_key or os.getenv("QBRAID_API_KEY", "").strip()
+    if not resolved_api_key:
+        logger.error("Missing qBraid API key. Set QBRAID_API_KEY or pass --api-key.")
+        sys.exit(1)
+
+    _validate_deploy_inputs(kernel_name, language, display_name)
+
     ctx_dir = Path(context_dir)
 
     # Encode Dockerfile
     logger.info(f"Encoding Dockerfile: {dockerfile}")
-    dockerfile_b64 = _encode_file(dockerfile)
+    dockerfile_content = dockerfile.read_text()
+    _validate_dockerfile_labels(dockerfile_content, kernel_name, language, display_name)
+    dockerfile_b64 = base64.b64encode(dockerfile_content.encode("utf-8")).decode(
+        "utf-8"
+    )
 
     # Collect context files
     logger.info(f"Collecting context files from: {ctx_dir}")
@@ -124,7 +233,7 @@ def deploy_kernel(
     # Submit deploy request
     logger.info(f"Deploying kernel '{kernel_name}' ({language})...")
     headers = {
-        "X-API-Key": api_key,
+        "X-API-Key": resolved_api_key,
         "Content-Type": "application/json",
     }
     payload = {
@@ -172,9 +281,9 @@ def deploy_kernel(
 
     # Poll for completion
     poll_url = f"{api_base_url}/kernels/deploy/{build_id}"
+    deadline = time.monotonic() + timeout_seconds
     for attempt in range(1, MAX_POLL_ATTEMPTS + 1):
         logger.info(f"Polling build status (attempt {attempt}/{MAX_POLL_ATTEMPTS})...")
-        time.sleep(POLL_INTERVAL_SECONDS)
 
         try:
             poll_resp = requests.get(
@@ -217,30 +326,35 @@ def deploy_kernel(
             write_github_output("status", "failed")
             sys.exit(1)
 
-    logger.error(
-        f"Build timed out after {MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS} seconds"
-    )
+        if time.monotonic() >= deadline:
+            break
+
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    logger.error(f"Build timed out after {timeout_seconds} seconds")
     write_github_output("status", "timeout")
     sys.exit(1)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Deploy a custom kernel to qBraid")
-    parser.add_argument("--api-key", required=True)
+    parser.add_argument("--api-key")
     parser.add_argument("--dockerfile-path", required=True)
     parser.add_argument("--kernel-name", required=True)
     parser.add_argument("--language", required=True)
     parser.add_argument("--display-name", required=True)
     parser.add_argument("--context-dir", default=".")
     parser.add_argument("--api-base-url", default="https://api-v2.qbraid.com/api/v1")
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
 
     args = parser.parse_args()
     deploy_kernel(
-        api_key=args.api_key,
         dockerfile_path=args.dockerfile_path,
         kernel_name=args.kernel_name,
         language=args.language,
         display_name=args.display_name,
         context_dir=args.context_dir,
         api_base_url=args.api_base_url,
+        api_key=args.api_key,
+        timeout_seconds=args.timeout_seconds,
     )

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import requests
 from context_files import list_context_files
@@ -158,6 +158,29 @@ def _validate_dockerfile_labels(
             sys.exit(1)
 
 
+def _build_resources(
+    cpu: Optional[str],
+    memory: Optional[str],
+    memory_limit: Optional[str],
+) -> Optional[Dict[str, str]]:
+    """Build the resources subdoc, omitting fields the caller did not supply.
+
+    Returning None when every input is empty means the API leaves the kernel's
+    existing resources untouched on a redeploy — callers who don't care about
+    sizing don't accidentally reset previously tuned values. The API enforces
+    a 2 vCPU / 4 GiB minimum and a 4 vCPU / 8 GiB maximum on any field that is
+    sent; sub-floor values come back as a 400 here, not a broken pod later.
+    """
+    resources: Dict[str, str] = {}
+    if cpu:
+        resources["defaultCpu"] = cpu
+    if memory:
+        resources["defaultMemory"] = memory
+    if memory_limit:
+        resources["defaultMemoryLimit"] = memory_limit
+    return resources or None
+
+
 def deploy_kernel(
     dockerfile_path: str,
     kernel_name: str,
@@ -167,6 +190,9 @@ def deploy_kernel(
     api_base_url: str,
     api_key: Optional[str] = None,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    cpu: Optional[str] = None,
+    memory: Optional[str] = None,
+    memory_limit: Optional[str] = None,
 ) -> None:
     """Deploy a custom kernel to qBraid."""
     dockerfile = Path(dockerfile_path)
@@ -201,7 +227,7 @@ def deploy_kernel(
         "X-API-Key": resolved_api_key,
         "Content-Type": "application/json",
     }
-    payload = {
+    payload: Dict[str, Any] = {
         "kernelName": kernel_name,
         "language": language,
         "displayName": display_name,
@@ -209,6 +235,11 @@ def deploy_kernel(
     }
     if context_files:
         payload["contextFiles"] = context_files
+
+    resources = _build_resources(cpu, memory, memory_limit)
+    if resources:
+        payload["resources"] = resources
+        logger.info("Requesting resources: %s", resources)
 
     url = f"{api_base_url}/kernels/deploy"
     try:
@@ -311,6 +342,9 @@ if __name__ == "__main__":
     parser.add_argument("--context-dir", default=".")
     parser.add_argument("--api-base-url", default="https://api-v2.qbraid.com/api/v1")
     parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--cpu", default=None)
+    parser.add_argument("--memory", default=None)
+    parser.add_argument("--memory-limit", default=None)
 
     args = parser.parse_args()
     deploy_kernel(
@@ -322,4 +356,7 @@ if __name__ == "__main__":
         api_base_url=args.api_base_url,
         api_key=args.api_key,
         timeout_seconds=args.timeout_seconds,
+        cpu=args.cpu or None,
+        memory=args.memory or None,
+        memory_limit=args.memory_limit or None,
     )

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -1,0 +1,185 @@
+# Copyright (C) 2026 qBraid
+
+import argparse
+import base64
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%H:%M:%S"
+)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+MAX_POLL_ATTEMPTS = 60
+POLL_INTERVAL_SECONDS = 30
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def write_github_output(key: str, value: str) -> None:
+    """Write a key-value pair to GITHUB_OUTPUT."""
+    if "GITHUB_OUTPUT" not in os.environ:
+        return
+    try:
+        output_file = os.environ["GITHUB_OUTPUT"]
+        with open(output_file, "a") as f:
+            f.write(f"{key}={value}\n")
+    except (IOError, OSError) as e:
+        logger.warning(f"Failed to write to GITHUB_OUTPUT: {e}")
+
+
+def _encode_file(path: Path) -> str:
+    """Base64-encode a file."""
+    return base64.b64encode(path.read_bytes()).decode("utf-8")
+
+
+def _collect_context_files(context_dir: Path, dockerfile_path: Path) -> Dict[str, str]:
+    """Collect and base64-encode context files from the context directory."""
+    context_files = {}
+    if not context_dir.is_dir():
+        return context_files
+
+    for item in context_dir.iterdir():
+        if item.is_file() and item != dockerfile_path and item.name != ".gitignore":
+            # Skip very large files (> 10MB)
+            if item.stat().st_size > 10 * 1024 * 1024:
+                logger.warning(f"Skipping large file: {item.name} ({item.stat().st_size} bytes)")
+                continue
+            context_files[item.name] = _encode_file(item)
+            logger.info(f"  Including context file: {item.name}")
+
+    return context_files
+
+
+def deploy_kernel(
+    api_key: str,
+    dockerfile_path: str,
+    kernel_name: str,
+    language: str,
+    display_name: str,
+    context_dir: str,
+    api_base_url: str,
+) -> None:
+    """Deploy a custom kernel to qBraid."""
+    dockerfile = Path(dockerfile_path)
+    if not dockerfile.exists():
+        logger.error(f"Dockerfile not found: {dockerfile}")
+        sys.exit(1)
+
+    ctx_dir = Path(context_dir)
+
+    # Encode Dockerfile
+    logger.info(f"Encoding Dockerfile: {dockerfile}")
+    dockerfile_b64 = _encode_file(dockerfile)
+
+    # Collect context files
+    logger.info(f"Collecting context files from: {ctx_dir}")
+    context_files = _collect_context_files(ctx_dir, dockerfile)
+
+    # Submit deploy request
+    logger.info(f"Deploying kernel '{kernel_name}' ({language})...")
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "kernelName": kernel_name,
+        "language": language,
+        "displayName": display_name,
+        "dockerfile": dockerfile_b64,
+    }
+    if context_files:
+        payload["contextFiles"] = context_files
+
+    url = f"{api_base_url}/kernels/deploy"
+    try:
+        resp = requests.post(url, headers=headers, json=payload, timeout=REQUEST_TIMEOUT_SECONDS)
+    except requests.RequestException as e:
+        logger.error(f"Failed to submit deploy request: {e}")
+        sys.exit(1)
+
+    if resp.status_code not in (200, 201):
+        logger.error(f"Deploy request failed: {resp.status_code} {resp.text}")
+        sys.exit(1)
+
+    resp_data = resp.json()
+    data = resp_data.get("data", resp_data)
+    build_id = data.get("buildId")
+    if not build_id:
+        logger.error("No build ID returned from API")
+        sys.exit(1)
+
+    logger.info(f"Build submitted. Build ID: {build_id}")
+    write_github_output("build-id", build_id)
+    write_github_output("kernel-name", kernel_name)
+
+    # Poll for completion
+    poll_url = f"{api_base_url}/kernels/deploy/{build_id}"
+    for attempt in range(1, MAX_POLL_ATTEMPTS + 1):
+        logger.info(f"Polling build status (attempt {attempt}/{MAX_POLL_ATTEMPTS})...")
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+        try:
+            poll_resp = requests.get(poll_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+        except requests.RequestException as e:
+            logger.warning(f"Poll request failed: {e}")
+            continue
+
+        if poll_resp.status_code != 200:
+            logger.warning(f"Poll returned {poll_resp.status_code}")
+            continue
+
+        poll_data = poll_resp.json()
+        status_data = poll_data.get("data", poll_data)
+        status = status_data.get("status", "unknown")
+        logger.info(f"Build status: {status}")
+
+        if status == "active":
+            logger.info(f"Kernel '{kernel_name}' deployed successfully!")
+            write_github_output("status", "active")
+            image_uri = status_data.get("imageUri", "")
+            if image_uri:
+                write_github_output("image-uri", image_uri)
+            return
+
+        if status == "failed":
+            error = status_data.get("error", "Unknown error")
+            logger.error(f"Kernel build failed: {error}")
+            write_github_output("status", "failed")
+            sys.exit(1)
+
+    logger.error(f"Build timed out after {MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS} seconds")
+    write_github_output("status", "timeout")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Deploy a custom kernel to qBraid")
+    parser.add_argument("--api-key", required=True)
+    parser.add_argument("--dockerfile-path", required=True)
+    parser.add_argument("--kernel-name", required=True)
+    parser.add_argument("--language", required=True)
+    parser.add_argument("--display-name", required=True)
+    parser.add_argument("--context-dir", default=".")
+    parser.add_argument("--api-base-url", default="https://api-v2.qbraid.com/api/v1")
+
+    args = parser.parse_args()
+    deploy_kernel(
+        api_key=args.api_key,
+        dockerfile_path=args.dockerfile_path,
+        kernel_name=args.kernel_name,
+        language=args.language,
+        display_name=args.display_name,
+        context_dir=args.context_dir,
+        api_base_url=args.api_base_url,
+    )

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -24,6 +24,7 @@ MAX_POLL_ATTEMPTS = 60
 POLL_INTERVAL_SECONDS = 30
 REQUEST_TIMEOUT_SECONDS = 30
 KERNEL_ALREADY_EXISTS_CODE = "KERNEL_ALREADY_EXISTS"
+FATAL_POLL_STATUS_CODES = {400, 401, 403, 404}
 
 
 def write_github_output(key: str, value: str) -> None:
@@ -54,6 +55,22 @@ def _parse_error_response(response: requests.Response) -> tuple[Optional[str], s
     error_code = error.get("code") if isinstance(error, dict) else None
     message = error.get("message") if isinstance(error, dict) else response.text
     return error_code, message or response.text
+
+
+def _parse_status_response(response: requests.Response) -> tuple[Optional[str], Optional[str]]:
+    """Extract a stable status/error pair from a deploy status response."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return None, response.text
+
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        return None, response.text
+
+    status = data.get("status")
+    error = data.get("error")
+    return status, error if isinstance(error, str) else None
 
 
 def _collect_context_files(context_dir: Path, dockerfile_path: Path) -> Dict[str, str]:
@@ -159,25 +176,35 @@ def deploy_kernel(
             continue
 
         if poll_resp.status_code != 200:
-            logger.warning(f"Poll returned {poll_resp.status_code}")
+            error_code, error_message = _parse_error_response(poll_resp)
+            log_message = (
+                f"Poll returned {poll_resp.status_code}"
+                f"{f' ({error_code})' if error_code else ''}: {error_message}"
+            )
+            if poll_resp.status_code in FATAL_POLL_STATUS_CODES:
+                logger.error(log_message)
+                write_github_output("status", "failed")
+                sys.exit(1)
+            logger.warning(log_message)
             continue
 
-        poll_data = poll_resp.json()
-        status_data = poll_data.get("data", poll_data)
-        status = status_data.get("status", "unknown")
+        status, error = _parse_status_response(poll_resp)
+        if not status:
+            logger.warning("Poll returned 200 without a readable build status")
+            continue
         logger.info(f"Build status: {status}")
 
         if status == "active":
             logger.info(f"Kernel '{kernel_name}' deployed successfully!")
             write_github_output("status", "active")
+            status_data = poll_resp.json().get("data", poll_resp.json())
             image_uri = status_data.get("imageUri", "")
             if image_uri:
                 write_github_output("image-uri", image_uri)
             return
 
         if status == "failed":
-            error = status_data.get("error", "Unknown error")
-            logger.error(f"Kernel build failed: {error}")
+            logger.error(f"Kernel build failed: {error or 'Unknown error'}")
             write_github_output("status", "failed")
             sys.exit(1)
 

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -2,7 +2,6 @@
 
 import argparse
 import base64
-import json
 import logging
 import os
 import sys
@@ -24,6 +23,7 @@ logger.setLevel(logging.INFO)
 MAX_POLL_ATTEMPTS = 60
 POLL_INTERVAL_SECONDS = 30
 REQUEST_TIMEOUT_SECONDS = 30
+KERNEL_ALREADY_EXISTS_CODE = "KERNEL_ALREADY_EXISTS"
 
 
 def write_github_output(key: str, value: str) -> None:
@@ -41,6 +41,19 @@ def write_github_output(key: str, value: str) -> None:
 def _encode_file(path: Path) -> str:
     """Base64-encode a file."""
     return base64.b64encode(path.read_bytes()).decode("utf-8")
+
+
+def _parse_error_response(response: requests.Response) -> tuple[Optional[str], str]:
+    """Extract a stable error code/message pair from qBraid API error responses."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return None, response.text
+
+    error = payload.get("error", payload)
+    error_code = error.get("code") if isinstance(error, dict) else None
+    message = error.get("message") if isinstance(error, dict) else response.text
+    return error_code, message or response.text
 
 
 def _collect_context_files(context_dir: Path, dockerfile_path: Path) -> Dict[str, str]:
@@ -109,7 +122,17 @@ def deploy_kernel(
         sys.exit(1)
 
     if resp.status_code not in (200, 201):
-        logger.error(f"Deploy request failed: {resp.status_code} {resp.text}")
+        error_code, error_message = _parse_error_response(resp)
+        if error_code == KERNEL_ALREADY_EXISTS_CODE:
+            logger.info(
+                "Kernel '%s' already exists and is active; treating deploy as successful.",
+                kernel_name,
+            )
+            write_github_output("kernel-name", kernel_name)
+            write_github_output("status", "active")
+            return
+
+        logger.error(f"Deploy request failed: {resp.status_code} {error_message}")
         sys.exit(1)
 
     resp_data = resp.json()

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -11,9 +11,9 @@ from typing import Dict, Optional
 
 import requests
 from validate_dockerfile import (
+    KERNEL_NAME_PATTERN,
     SUPPORTED_LANGUAGES,
     extract_dockerfile_labels,
-    KERNEL_NAME_PATTERN,
 )
 
 logger = logging.getLogger(__name__)

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -12,12 +12,13 @@ from typing import Dict, Optional
 import requests
 
 logger = logging.getLogger(__name__)
-handler = logging.StreamHandler(sys.stdout)
-formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%H:%M:%S"
-)
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+if not logger.handlers:
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%H:%M:%S"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 MAX_POLL_ATTEMPTS = 60
@@ -57,7 +58,9 @@ def _parse_error_response(response: requests.Response) -> tuple[Optional[str], s
     return error_code, message or response.text
 
 
-def _parse_status_response(response: requests.Response) -> tuple[Optional[str], Optional[str]]:
+def _parse_status_response(
+    response: requests.Response,
+) -> tuple[Optional[str], Optional[str]]:
     """Extract a stable status/error pair from a deploy status response."""
     try:
         payload = response.json()
@@ -83,7 +86,9 @@ def _collect_context_files(context_dir: Path, dockerfile_path: Path) -> Dict[str
         if item.is_file() and item != dockerfile_path and item.name != ".gitignore":
             # Skip very large files (> 10MB)
             if item.stat().st_size > 10 * 1024 * 1024:
-                logger.warning(f"Skipping large file: {item.name} ({item.stat().st_size} bytes)")
+                logger.warning(
+                    f"Skipping large file: {item.name} ({item.stat().st_size} bytes)"
+                )
                 continue
             context_files[item.name] = _encode_file(item)
             logger.info(f"  Including context file: {item.name}")
@@ -133,7 +138,9 @@ def deploy_kernel(
 
     url = f"{api_base_url}/kernels/deploy"
     try:
-        resp = requests.post(url, headers=headers, json=payload, timeout=REQUEST_TIMEOUT_SECONDS)
+        resp = requests.post(
+            url, headers=headers, json=payload, timeout=REQUEST_TIMEOUT_SECONDS
+        )
     except requests.RequestException as e:
         logger.error(f"Failed to submit deploy request: {e}")
         sys.exit(1)
@@ -170,7 +177,9 @@ def deploy_kernel(
         time.sleep(POLL_INTERVAL_SECONDS)
 
         try:
-            poll_resp = requests.get(poll_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+            poll_resp = requests.get(
+                poll_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+            )
         except requests.RequestException as e:
             logger.warning(f"Poll request failed: {e}")
             continue
@@ -208,7 +217,9 @@ def deploy_kernel(
             write_github_output("status", "failed")
             sys.exit(1)
 
-    logger.error(f"Build timed out after {MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS} seconds")
+    logger.error(
+        f"Build timed out after {MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS} seconds"
+    )
     write_github_output("status", "timeout")
     sys.exit(1)
 

--- a/deploy-kernel/src/scripts/deploy_kernel.py
+++ b/deploy-kernel/src/scripts/deploy_kernel.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import requests
+from context_files import list_context_files
 from validate_dockerfile import (
     KERNEL_NAME_PATTERN,
     SUPPORTED_LANGUAGES,
@@ -32,24 +33,6 @@ REQUEST_TIMEOUT_SECONDS = 30
 KERNEL_ALREADY_EXISTS_CODE = "KERNEL_ALREADY_EXISTS"
 FATAL_POLL_STATUS_CODES = {400, 401, 403, 404}
 DEFAULT_TIMEOUT_SECONDS = 1800
-SKIPPED_CONTEXT_FILES = frozenset(
-    {
-        ".gitignore",
-        ".dockerignore",
-        ".env",
-        ".env.local",
-        ".env.production",
-        ".env.staging",
-        ".npmrc",
-        ".pypirc",
-        ".netrc",
-        "id_rsa",
-        "id_ed25519",
-        "credentials",
-    }
-)
-SKIPPED_CONTEXT_SUFFIXES = (".pem", ".key", ".p12", ".crt", ".kubeconfig")
-SKIPPED_CONTEXT_SUBSTRINGS = ("secret", "token", "password", "credential")
 
 
 def write_github_output(key: str, value: str) -> None:
@@ -113,35 +96,17 @@ def _parse_status_response(
 
 
 def _collect_context_files(context_dir: Path, dockerfile_path: Path) -> Dict[str, str]:
-    """Collect and base64-encode context files from the context directory."""
-    context_files = {}
-    if not context_dir.is_dir():
-        return context_files
+    """Collect and base64-encode context files from the context directory.
 
-    for item in context_dir.iterdir():
-        if not item.is_file() or item == dockerfile_path:
-            continue
-
-        item_name = item.name
-        lowered_name = item_name.lower()
-        if (
-            item_name in SKIPPED_CONTEXT_FILES
-            or item_name.startswith(".")
-            or lowered_name.endswith(SKIPPED_CONTEXT_SUFFIXES)
-            or any(part in lowered_name for part in SKIPPED_CONTEXT_SUBSTRINGS)
-        ):
-            logger.info(f"  Skipping sensitive context file: {item_name}")
-            continue
-
-        # Skip very large files (> 10MB)
-        if item.stat().st_size > 10 * 1024 * 1024:
-            logger.warning(
-                f"Skipping large file: {item.name} ({item.stat().st_size} bytes)"
-            )
-            continue
-        context_files[item.name] = _encode_file(item)
-        logger.info(f"  Including context file: {item.name}")
-
+    Uses ``list_context_files`` so the preflight validator (which consults
+    the same listing) sees exactly what reaches Cloud Build — preventing
+    skew between "what passed validation" and "what got uploaded".
+    """
+    context_files: Dict[str, str] = {}
+    for name in list_context_files(context_dir, dockerfile_path):
+        path = context_dir / name
+        context_files[name] = _encode_file(path)
+        logger.info(f"  Including context file: {name}")
     return context_files
 
 

--- a/deploy-kernel/src/scripts/validate_dockerfile.py
+++ b/deploy-kernel/src/scripts/validate_dockerfile.py
@@ -1,184 +1,43 @@
-# Copyright (C) 2026 qBraid
-# Symlink / copy of upload-course-action/src/scripts/validate_dockerfile.py
-# This file re-exports the Dockerfile validation for use in the deploy-kernel-action.
+"""Delegate deploy-kernel Dockerfile validation to the shared validator."""
 
-import logging
-import re
+from __future__ import annotations
+
+import importlib.util
 import sys
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
-
-logger = logging.getLogger(__name__)
-handler = logging.StreamHandler(sys.stdout)
-formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%H:%M:%S"
-)
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
-KERNEL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{2,63}$")
-
-SUPPORTED_LANGUAGES = frozenset(
-    {"python", "cpp", "julia", "r", "rust", "go", "javascript"}
-)
-
-REQUIRED_LABELS = frozenset(
-    {"qbraid.kernel.name", "qbraid.kernel.language", "qbraid.kernel.display_name"}
-)
 
 
-@dataclass
-class DockerfileValidationResult:
-    errors: List[str] = field(default_factory=list)
+def _load_shared_validator_module():
+    repo_root = Path(__file__).resolve().parents[3]
+    shared_validator_path = repo_root / "src" / "scripts" / "validate_dockerfile.py"
 
-    @property
-    def is_valid(self) -> bool:
-        return len(self.errors) == 0
-
-    def add_error(self, msg: str) -> None:
-        self.errors.append(msg)
-
-
-def _parse_labels(lines: List[str]) -> Dict[str, str]:
-    labels: Dict[str, str] = {}
-    for line in lines:
-        stripped = line.strip()
-        if not stripped.upper().startswith("LABEL "):
-            continue
-        content = stripped[6:].strip()
-        parts = re.findall(r'(\S+?)=("[^"]*"|\S+)', content)
-        for key, value in parts:
-            labels[key] = value.strip('"')
-    return labels
-
-
-def _join_continuation_lines(raw_lines: List[str]) -> List[str]:
-    joined: List[str] = []
-    current = ""
-    for line in raw_lines:
-        stripped = line.rstrip()
-        if stripped.lstrip().startswith("#"):
-            continue
-        if stripped.endswith("\\"):
-            current += stripped[:-1] + " "
-        else:
-            current += stripped
-            if current.strip():
-                joined.append(current)
-            current = ""
-    if current.strip():
-        joined.append(current)
-    return joined
-
-
-def validate_dockerfile(content: str) -> DockerfileValidationResult:
-    result = DockerfileValidationResult()
-
-    if not content.strip():
-        result.add_error("Dockerfile is empty")
-        return result
-
-    raw_lines = content.splitlines()
-    lines = _join_continuation_lines(raw_lines)
-
-    if not lines:
-        result.add_error("Dockerfile contains no instructions")
-        return result
-
-    labels = _parse_labels(lines)
-    for required_label in REQUIRED_LABELS:
-        if required_label not in labels:
-            result.add_error(f"Missing required LABEL: {required_label}")
-
-    kernel_name = labels.get("qbraid.kernel.name", "")
-    if kernel_name and not KERNEL_NAME_PATTERN.match(kernel_name):
-        result.add_error(
-            f'LABEL qbraid.kernel.name "{kernel_name}" is invalid. '
-            "Must start with lowercase letter, contain only lowercase letters, digits, underscores (3-64 chars)"
-        )
-
-    language = labels.get("qbraid.kernel.language", "")
-    if language and language not in SUPPORTED_LANGUAGES:
-        result.add_error(
-            f'LABEL qbraid.kernel.language "{language}" not supported. '
-            f"Supported: {', '.join(sorted(SUPPORTED_LANGUAGES))}"
-        )
-
-    display_name = labels.get("qbraid.kernel.display_name", "")
-    if "qbraid.kernel.display_name" in labels and not display_name:
-        result.add_error("LABEL qbraid.kernel.display_name cannot be empty")
-
-    has_expose = any(
-        line.strip().upper().startswith("EXPOSE ")
-        and ("8888" in line.strip().split())
-        for line in lines
+    spec = importlib.util.spec_from_file_location(
+        "shared_validate_dockerfile", shared_validator_path
     )
-    if not has_expose:
-        result.add_error("Missing EXPOSE 8888 (required for kernel gateway)")
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load shared validator from {shared_validator_path}")
 
-    last_cmd = None
-    for line in lines:
-        upper = line.strip().upper()
-        if upper.startswith("CMD ") or upper.startswith("ENTRYPOINT "):
-            last_cmd = line.strip()
-    if last_cmd is None:
-        result.add_error("Missing CMD or ENTRYPOINT. Must reference 'jupyter kernelgateway'")
-    elif "kernelgateway" not in last_cmd.lower() and "kernel_gateway" not in last_cmd.lower():
-        result.add_error(f"CMD/ENTRYPOINT must reference 'jupyter kernelgateway'. Found: {last_cmd}")
-
-    last_user = None
-    for line in lines:
-        if line.strip().upper().startswith("USER "):
-            last_user = line.strip()[5:].strip()
-    if last_user and last_user.lower() in ("root", "0"):
-        result.add_error("Final USER directive must not be root (security requirement)")
-
-    has_privileged = any("--privileged" in line or "--cap-add=SYS_ADMIN" in line for line in lines)
-    if has_privileged:
-        result.add_error("Dockerfile must not use --privileged or --cap-add=SYS_ADMIN")
-
-    has_kernel_json = any(
-        (
-            (line.strip().upper().startswith("COPY ") or line.strip().upper().startswith("ADD "))
-            and "kernel.json" in line
-        )
-        or (
-            line.strip().upper().startswith("RUN ")
-            and "kernel.json" in line
-            and any(kw in line.lower() for kw in ("echo", "cat", "tee", "kernelspec"))
-        )
-        for line in lines
-    )
-    if not has_kernel_json:
-        result.add_error(
-            "kernel.json must be COPY'd, ADD'd, or created via RUN in the Dockerfile"
-        )
-
-    return result
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(shared_validator_path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
 
 
-def validate_dockerfile_file(dockerfile_path: str) -> None:
-    path = Path(dockerfile_path)
-    if not path.exists():
-        logger.error(f"Dockerfile not found: {path}")
-        sys.exit(1)
+_shared_validator = _load_shared_validator_module()
 
-    content = path.read_text()
-    result = validate_dockerfile(content)
-
-    if not result.is_valid:
-        logger.error("Dockerfile validation failed:")
-        for error in result.errors:
-            logger.error(f"  - {error}")
-        sys.exit(1)
-
-    logger.info("Dockerfile validation passed")
+DockerfileValidationResult = _shared_validator.DockerfileValidationResult
+KERNEL_NAME_PATTERN = _shared_validator.KERNEL_NAME_PATTERN
+SUPPORTED_LANGUAGES = _shared_validator.SUPPORTED_LANGUAGES
+REQUIRED_LABELS = _shared_validator.REQUIRED_LABELS
+validate_dockerfile = _shared_validator.validate_dockerfile
+validate_dockerfile_file = _shared_validator.validate_dockerfile_file
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        logger.error("Usage: python validate_dockerfile.py <dockerfile_path>")
+        print("Usage: python validate_dockerfile.py <dockerfile_path>", file=sys.stderr)
         sys.exit(1)
     validate_dockerfile_file(sys.argv[1])

--- a/deploy-kernel/src/scripts/validate_dockerfile.py
+++ b/deploy-kernel/src/scripts/validate_dockerfile.py
@@ -15,7 +15,9 @@ def _load_shared_validator_module():
         "shared_validate_dockerfile", shared_validator_path
     )
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"Unable to load shared validator from {shared_validator_path}")
+        raise RuntimeError(
+            f"Unable to load shared validator from {shared_validator_path}"
+        )
 
     module = importlib.util.module_from_spec(spec)
     sys.path.insert(0, str(shared_validator_path.parent))

--- a/deploy-kernel/src/scripts/validate_dockerfile.py
+++ b/deploy-kernel/src/scripts/validate_dockerfile.py
@@ -1,0 +1,184 @@
+# Copyright (C) 2026 qBraid
+# Symlink / copy of upload-course-action/src/scripts/validate_dockerfile.py
+# This file re-exports the Dockerfile validation for use in the deploy-kernel-action.
+
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%H:%M:%S"
+)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+KERNEL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{2,63}$")
+
+SUPPORTED_LANGUAGES = frozenset(
+    {"python", "cpp", "julia", "r", "rust", "go", "javascript"}
+)
+
+REQUIRED_LABELS = frozenset(
+    {"qbraid.kernel.name", "qbraid.kernel.language", "qbraid.kernel.display_name"}
+)
+
+
+@dataclass
+class DockerfileValidationResult:
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+    def add_error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+
+def _parse_labels(lines: List[str]) -> Dict[str, str]:
+    labels: Dict[str, str] = {}
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.upper().startswith("LABEL "):
+            continue
+        content = stripped[6:].strip()
+        parts = re.findall(r'(\S+?)=("[^"]*"|\S+)', content)
+        for key, value in parts:
+            labels[key] = value.strip('"')
+    return labels
+
+
+def _join_continuation_lines(raw_lines: List[str]) -> List[str]:
+    joined: List[str] = []
+    current = ""
+    for line in raw_lines:
+        stripped = line.rstrip()
+        if stripped.lstrip().startswith("#"):
+            continue
+        if stripped.endswith("\\"):
+            current += stripped[:-1] + " "
+        else:
+            current += stripped
+            if current.strip():
+                joined.append(current)
+            current = ""
+    if current.strip():
+        joined.append(current)
+    return joined
+
+
+def validate_dockerfile(content: str) -> DockerfileValidationResult:
+    result = DockerfileValidationResult()
+
+    if not content.strip():
+        result.add_error("Dockerfile is empty")
+        return result
+
+    raw_lines = content.splitlines()
+    lines = _join_continuation_lines(raw_lines)
+
+    if not lines:
+        result.add_error("Dockerfile contains no instructions")
+        return result
+
+    labels = _parse_labels(lines)
+    for required_label in REQUIRED_LABELS:
+        if required_label not in labels:
+            result.add_error(f"Missing required LABEL: {required_label}")
+
+    kernel_name = labels.get("qbraid.kernel.name", "")
+    if kernel_name and not KERNEL_NAME_PATTERN.match(kernel_name):
+        result.add_error(
+            f'LABEL qbraid.kernel.name "{kernel_name}" is invalid. '
+            "Must start with lowercase letter, contain only lowercase letters, digits, underscores (3-64 chars)"
+        )
+
+    language = labels.get("qbraid.kernel.language", "")
+    if language and language not in SUPPORTED_LANGUAGES:
+        result.add_error(
+            f'LABEL qbraid.kernel.language "{language}" not supported. '
+            f"Supported: {', '.join(sorted(SUPPORTED_LANGUAGES))}"
+        )
+
+    display_name = labels.get("qbraid.kernel.display_name", "")
+    if "qbraid.kernel.display_name" in labels and not display_name:
+        result.add_error("LABEL qbraid.kernel.display_name cannot be empty")
+
+    has_expose = any(
+        line.strip().upper().startswith("EXPOSE ")
+        and ("8888" in line.strip().split())
+        for line in lines
+    )
+    if not has_expose:
+        result.add_error("Missing EXPOSE 8888 (required for kernel gateway)")
+
+    last_cmd = None
+    for line in lines:
+        upper = line.strip().upper()
+        if upper.startswith("CMD ") or upper.startswith("ENTRYPOINT "):
+            last_cmd = line.strip()
+    if last_cmd is None:
+        result.add_error("Missing CMD or ENTRYPOINT. Must reference 'jupyter kernelgateway'")
+    elif "kernelgateway" not in last_cmd.lower() and "kernel_gateway" not in last_cmd.lower():
+        result.add_error(f"CMD/ENTRYPOINT must reference 'jupyter kernelgateway'. Found: {last_cmd}")
+
+    last_user = None
+    for line in lines:
+        if line.strip().upper().startswith("USER "):
+            last_user = line.strip()[5:].strip()
+    if last_user and last_user.lower() in ("root", "0"):
+        result.add_error("Final USER directive must not be root (security requirement)")
+
+    has_privileged = any("--privileged" in line or "--cap-add=SYS_ADMIN" in line for line in lines)
+    if has_privileged:
+        result.add_error("Dockerfile must not use --privileged or --cap-add=SYS_ADMIN")
+
+    has_kernel_json = any(
+        (
+            (line.strip().upper().startswith("COPY ") or line.strip().upper().startswith("ADD "))
+            and "kernel.json" in line
+        )
+        or (
+            line.strip().upper().startswith("RUN ")
+            and "kernel.json" in line
+            and any(kw in line.lower() for kw in ("echo", "cat", "tee", "kernelspec"))
+        )
+        for line in lines
+    )
+    if not has_kernel_json:
+        result.add_error(
+            "kernel.json must be COPY'd, ADD'd, or created via RUN in the Dockerfile"
+        )
+
+    return result
+
+
+def validate_dockerfile_file(dockerfile_path: str) -> None:
+    path = Path(dockerfile_path)
+    if not path.exists():
+        logger.error(f"Dockerfile not found: {path}")
+        sys.exit(1)
+
+    content = path.read_text()
+    result = validate_dockerfile(content)
+
+    if not result.is_valid:
+        logger.error("Dockerfile validation failed:")
+        for error in result.errors:
+            logger.error(f"  - {error}")
+        sys.exit(1)
+
+    logger.info("Dockerfile validation passed")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        logger.error("Usage: python validate_dockerfile.py <dockerfile_path>")
+        sys.exit(1)
+    validate_dockerfile_file(sys.argv[1])

--- a/deploy-kernel/src/scripts/validate_dockerfile.py
+++ b/deploy-kernel/src/scripts/validate_dockerfile.py
@@ -39,6 +39,10 @@ validate_dockerfile_file = _shared_validator.validate_dockerfile_file
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python validate_dockerfile.py <dockerfile_path>", file=sys.stderr)
+        print(
+            "Usage: python validate_dockerfile.py <dockerfile_path> [<context_dir>]",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    validate_dockerfile_file(sys.argv[1])
+    ctx = sys.argv[2] if len(sys.argv) >= 3 else None
+    validate_dockerfile_file(sys.argv[1], ctx)

--- a/deploy-kernel/src/scripts/validate_dockerfile.py
+++ b/deploy-kernel/src/scripts/validate_dockerfile.py
@@ -32,6 +32,7 @@ DockerfileValidationResult = _shared_validator.DockerfileValidationResult
 KERNEL_NAME_PATTERN = _shared_validator.KERNEL_NAME_PATTERN
 SUPPORTED_LANGUAGES = _shared_validator.SUPPORTED_LANGUAGES
 REQUIRED_LABELS = _shared_validator.REQUIRED_LABELS
+extract_dockerfile_labels = _shared_validator.extract_dockerfile_labels
 validate_dockerfile = _shared_validator.validate_dockerfile
 validate_dockerfile_file = _shared_validator.validate_dockerfile_file
 

--- a/examples/Dockerfile.kernel
+++ b/examples/Dockerfile.kernel
@@ -1,0 +1,38 @@
+# Example Dockerfile for custom kernel deployment to qBraid
+# This file must be named Dockerfile.kernel (or the path specified in your workflow)
+# See: https://docs.qbraid.com/docs/kernels/custom-kernels
+
+FROM jupyter/base-notebook:latest
+
+# Required labels for qBraid kernel registration
+LABEL qbraid.kernel.name="my_custom_kernel"
+LABEL qbraid.kernel.language="python"
+LABEL qbraid.kernel.display_name="My Custom Kernel"
+
+# Switch to root for system-level installs
+USER root
+
+# Install dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Install the kernel system-wide (root can write to /usr/local/share/jupyter)
+RUN python -m ipykernel install \
+    --name "my_custom_kernel" \
+    --display-name "My Custom Kernel"
+
+# kernel.json is already created by ipykernel install above,
+# but override it with your custom config if needed
+RUN echo '{"argv":["python","-m","ipykernel_launcher","-f","{connection_file}"],"display_name":"My Custom Kernel","language":"python"}' \
+    > /usr/local/share/jupyter/kernels/my_custom_kernel/kernel.json
+
+# Switch back to non-root user (security requirement)
+USER ${NB_UID}
+
+EXPOSE 8888
+WORKDIR /home/jovyan
+
+CMD ["jupyter", "kernelgateway", \
+     "--KernelGatewayApp.ip=0.0.0.0", \
+     "--KernelGatewayApp.port=8888", \
+     "--KernelGatewayApp.allow_origin=*"]

--- a/examples/deploy-kernel-workflow.yml
+++ b/examples/deploy-kernel-workflow.yml
@@ -1,0 +1,60 @@
+name: Deploy Custom Kernel to qBraid
+
+on:
+  workflow_dispatch:
+    inputs:
+      kernel-name:
+        description: 'Kernel name (lowercase, alphanumeric + underscore, 3-64 chars)'
+        required: true
+        type: string
+      language:
+        description: 'Programming language'
+        required: true
+        type: choice
+        options:
+          - python
+          - cpp
+          - julia
+          - r
+          - rust
+          - go
+          - javascript
+      display-name:
+        description: 'Human-readable display name for the kernel'
+        required: false
+        type: string
+      api-base-url:
+        description: 'qBraid API base URL (leave blank for default)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-kernel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy kernel to qBraid
+        id: deploy-kernel
+        uses: qBraid/upload-course-action/deploy-kernel@kernel-deployment-v0.0-beta.0.1  # ✅ repo/subdir@tag
+        with:
+          api-key:          ${{ secrets.QBRAID_API_KEY }}
+          kernel-name:      ${{ github.event.inputs.kernel-name || 'my_custom_kernel' }}
+          language:         ${{ github.event.inputs.language || 'python' }}
+          display-name:     ${{ github.event.inputs.display-name || 'My Custom Kernel' }}
+          dockerfile-path:  'Dockerfile.kernel'
+          context-dir:      './kernel-spec'
+          api-base-url:     ${{ github.event.inputs.api-base-url || 'https://api-v2.qbraid.com/api/v1' }}
+
+      - name: Show deployment results
+        if: success()
+        run: |
+          echo "✅ Kernel deployed successfully!"
+          echo "Kernel Name:  ${{ steps.deploy-kernel.outputs.kernel-name }}"
+          echo "Image URI:    ${{ steps.deploy-kernel.outputs.image-uri }}"
+          echo "Build ID:     ${{ steps.deploy-kernel.outputs.build-id }}"
+          echo "Status:       ${{ steps.deploy-kernel.outputs.status }}"

--- a/examples/requirements.kernel.txt
+++ b/examples/requirements.kernel.txt
@@ -1,0 +1,7 @@
+# Example requirements.txt for custom kernel
+# Include any additional packages your kernel needs
+
+numpy
+pandas
+scikit-learn
+matplotlib

--- a/src/scripts/context_files.py
+++ b/src/scripts/context_files.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2026 qBraid
+
+"""Single source of truth for what gets uploaded as Cloud Build context.
+
+Both the deploy-kernel action's upload step and the Dockerfile validator
+need to agree on the set of files that will end up in the tarball. Without
+a shared listing, a validator that walks the raw filesystem would mismatch
+the uploader's sensitive-file filter and produce false positives (or, the
+other way around, false negatives that let a broken Dockerfile through).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Set
+
+from common import setup_logging
+
+logger = setup_logging(__name__)
+
+MAX_CONTEXT_FILE_BYTES = 10 * 1024 * 1024
+
+SKIPPED_CONTEXT_FILES = frozenset(
+    {
+        ".gitignore",
+        ".dockerignore",
+        ".env",
+        ".env.local",
+        ".env.production",
+        ".env.staging",
+        ".npmrc",
+        ".pypirc",
+        ".netrc",
+        "id_rsa",
+        "id_ed25519",
+        "credentials",
+    }
+)
+SKIPPED_CONTEXT_SUFFIXES = (".pem", ".key", ".p12", ".crt", ".kubeconfig")
+SKIPPED_CONTEXT_SUBSTRINGS = ("secret", "token", "password", "credential")
+
+
+def is_skipped_context_file(name: str) -> bool:
+    """Return True for files we refuse to ship as build context.
+
+    Matches three filters: explicit deny-list, sensitive suffixes, and
+    sensitive substrings. Also skips dotfiles, which generally hold local
+    config that should not enter a public image.
+    """
+    if name in SKIPPED_CONTEXT_FILES or name.startswith("."):
+        return True
+    lowered = name.lower()
+    if lowered.endswith(SKIPPED_CONTEXT_SUFFIXES):
+        return True
+    return any(part in lowered for part in SKIPPED_CONTEXT_SUBSTRINGS)
+
+
+def list_context_files(context_dir: Path, dockerfile_path: Path) -> Set[str]:
+    """Names of files that will reach Cloud Build as build context.
+
+    Mirrors the filter the uploader applies, so a preflight validator that
+    consults this set sees exactly what `_collect_context_files` will ship.
+    Reasons a file would be skipped (sensitive name, oversize) are logged
+    once here; the uploader does not need to re-log them.
+    """
+    names: Set[str] = set()
+    if not context_dir.is_dir():
+        return names
+
+    for item in context_dir.iterdir():
+        if not item.is_file() or item == dockerfile_path:
+            continue
+        if is_skipped_context_file(item.name):
+            logger.info("  Skipping sensitive context file: %s", item.name)
+            continue
+        if item.stat().st_size > MAX_CONTEXT_FILE_BYTES:
+            logger.warning(
+                "Skipping large file: %s (%d bytes)",
+                item.name,
+                item.stat().st_size,
+            )
+            continue
+        names.add(item.name)
+    return names

--- a/src/scripts/validate_course.py
+++ b/src/scripts/validate_course.py
@@ -95,6 +95,45 @@ class Course(BaseModel):
             )
         return v
 
+    @field_validator("content")
+    @classmethod
+    def check_kernel_references(cls, chapters: List["Chapter"]) -> List["Chapter"]:
+        """Validate all kernel references exist in the kernel catalog."""
+        catalog_url = os.environ.get(
+            "KERNEL_CATALOG_URL",
+            "https://qbook-staging.k8s.qbraid.com/api/kernelspecs",
+        )
+
+        try:
+            import urllib.request
+
+            with urllib.request.urlopen(catalog_url, timeout=10) as resp:
+                catalog = json.loads(resp.read().decode())
+            available_kernels = set(catalog.get("kernels", {}).keys())
+        except Exception:
+            logger.warning(
+                "Could not fetch kernel catalog; skipping kernel name validation"
+            )
+            return chapters
+
+        if not available_kernels:
+            logger.warning("Kernel catalog is empty; skipping kernel name validation")
+            return chapters
+
+        for chapter in chapters:
+            if chapter.kernelName not in available_kernels:
+                raise ValueError(
+                    f"Kernel '{chapter.kernelName}' not found in catalog. "
+                    f"Available: {sorted(available_kernels)}"
+                )
+            for section in chapter.sections or []:
+                if section.kernelName not in available_kernels:
+                    raise ValueError(
+                        f"Kernel '{section.kernelName}' not found in catalog. "
+                        f"Available: {sorted(available_kernels)}"
+                    )
+        return chapters
+
 
 class CourseValidator:
     """Validates the course.json structure and file sizes."""

--- a/src/scripts/validate_course.py
+++ b/src/scripts/validate_course.py
@@ -1,18 +1,47 @@
 # Copyright (C) 2026 qBraid
 
-
 import json
 import os
 import sys
+import urllib.request
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional, Set
 
 from common import Config
-from common import ValidationError as ActionValidationError
 from common import setup_logging
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 logger = setup_logging(__name__)
+
+MAX_KERNEL_NAME_SAMPLE = 10
+
+
+def _fetch_available_kernels(catalog_url: str) -> Optional[Set[str]]:
+    """Fetch the available kernel names from the configured catalog."""
+    try:
+        with urllib.request.urlopen(catalog_url, timeout=10) as resp:
+            catalog = json.loads(resp.read().decode())
+    except Exception:
+        logger.warning("Could not fetch kernel catalog from %s", catalog_url)
+        return None
+
+    kernels = set(catalog.get("kernels", {}).keys())
+    if not kernels:
+        logger.warning("Kernel catalog at %s is empty", catalog_url)
+        return None
+    return kernels
+
+
+def _format_missing_kernel_error(
+    kernel_name: str, catalog_url: str, available_kernels: Set[str]
+) -> str:
+    """Build a concise missing-kernel error without dumping the full catalog."""
+    sample = ", ".join(sorted(available_kernels)[:MAX_KERNEL_NAME_SAMPLE])
+    suffix = "" if len(available_kernels) <= MAX_KERNEL_NAME_SAMPLE else ", ..."
+    return (
+        f"Kernel '{kernel_name}' not found in catalog at {catalog_url}. "
+        f"Catalog contains {len(available_kernels)} kernels. Sample: [{sample}{suffix}]"
+    )
 
 
 class ImageLink(BaseModel):
@@ -98,39 +127,29 @@ class Course(BaseModel):
     @field_validator("content")
     @classmethod
     def check_kernel_references(cls, chapters: List["Chapter"]) -> List["Chapter"]:
-        """Validate all kernel references exist in the kernel catalog."""
-        catalog_url = os.environ.get(
-            "KERNEL_CATALOG_URL",
-            "https://qbook-staging.k8s.qbraid.com/api/kernelspecs",
-        )
-
-        try:
-            import urllib.request
-
-            with urllib.request.urlopen(catalog_url, timeout=10) as resp:
-                catalog = json.loads(resp.read().decode())
-            available_kernels = set(catalog.get("kernels", {}).keys())
-        except Exception:
-            logger.warning(
-                "Could not fetch kernel catalog; skipping kernel name validation"
-            )
+        """Validate kernel references when a catalog URL is explicitly configured."""
+        catalog_url = os.environ.get("KERNEL_CATALOG_URL")
+        if not catalog_url:
             return chapters
 
+        available_kernels = _fetch_available_kernels(catalog_url)
         if not available_kernels:
-            logger.warning("Kernel catalog is empty; skipping kernel name validation")
+            logger.warning("Skipping kernel name validation")
             return chapters
 
         for chapter in chapters:
             if chapter.kernelName not in available_kernels:
                 raise ValueError(
-                    f"Kernel '{chapter.kernelName}' not found in catalog. "
-                    f"Available: {sorted(available_kernels)}"
+                    _format_missing_kernel_error(
+                        chapter.kernelName, catalog_url, available_kernels
+                    )
                 )
             for section in chapter.sections or []:
                 if section.kernelName not in available_kernels:
                     raise ValueError(
-                        f"Kernel '{section.kernelName}' not found in catalog. "
-                        f"Available: {sorted(available_kernels)}"
+                        _format_missing_kernel_error(
+                            section.kernelName, catalog_url, available_kernels
+                        )
                     )
         return chapters
 
@@ -161,7 +180,7 @@ class CourseValidator:
         except ValidationError as e:
             logger.error("Validation failed for course.json")
             for error in e.errors():
-                loc = " -> ".join(str(l) for l in error["loc"])
+                loc = " -> ".join(str(location) for location in error["loc"])
                 logger.error(f"  Field: {loc}")
                 logger.error(f"  Error: {error['msg']}")
             sys.exit(1)

--- a/src/scripts/validate_course.py
+++ b/src/scripts/validate_course.py
@@ -7,8 +7,7 @@ import urllib.request
 from pathlib import Path
 from typing import List, Optional, Set
 
-from common import Config
-from common import setup_logging
+from common import Config, setup_logging
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 logger = setup_logging(__name__)

--- a/src/scripts/validate_dockerfile.py
+++ b/src/scripts/validate_dockerfile.py
@@ -1,12 +1,15 @@
 # Copyright (C) 2026 qBraid
 
+import json
 import re
+import shlex
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from common import setup_logging
+from context_files import list_context_files
 
 logger = setup_logging(__name__)
 
@@ -141,7 +144,79 @@ def _join_continuation_lines(raw_lines: List[str]) -> List[str]:
     return joined
 
 
-def validate_dockerfile(content: str) -> DockerfileValidationResult:
+def _parse_copy_add_sources(line: str) -> Optional[List[str]]:
+    """Return source paths from a COPY/ADD line, or None to skip.
+
+    None means: not a COPY/ADD, multi-stage `--from=` copy (reads from
+    another build stage, not the context), or a syntactically odd line
+    we don't want to flag here.
+    """
+    stripped = line.strip()
+    upper = stripped.upper()
+    if not (upper.startswith("COPY ") or upper.startswith("ADD ")):
+        return None
+
+    args_str = stripped.split(None, 1)[1]
+    if args_str.lstrip().startswith("["):
+        try:
+            tokens = json.loads(args_str)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(tokens, list) or len(tokens) < 2:
+            return None
+    else:
+        try:
+            tokens = shlex.split(args_str)
+        except ValueError:
+            return None
+
+    tokens = [
+        t for t in tokens if not (t.startswith("--chown=") or t.startswith("--chmod="))
+    ]
+    if any(t.startswith("--from=") for t in tokens):
+        return None
+    tokens = [t for t in tokens if not t.startswith("--")]
+    if len(tokens) < 2:
+        return None
+    return tokens[:-1]
+
+
+def _check_copy_add_sources(
+    lines: List[str], available: Set[str]
+) -> List[str]:
+    """Errors for COPY/ADD source paths missing from the packaged context.
+
+    URLs and `${VAR}` build-arg interpolations are skipped — the former
+    are pulled by Docker at build time, the latter can't be resolved
+    statically. Top-level segment is checked against `available` so a
+    `COPY src/main.py …` line passes when `src` is in the context dir.
+    """
+    errors: List[str] = []
+    for line in lines:
+        sources = _parse_copy_add_sources(line)
+        if sources is None:
+            continue
+        for src in sources:
+            if "://" in src:
+                continue
+            if "$" in src:
+                logger.warning(
+                    "Skipping COPY/ADD source with build-arg interpolation: %s",
+                    src,
+                )
+                continue
+            normalized = src.lstrip("./")
+            top = normalized.split("/", 1)[0]
+            if top and top not in available:
+                errors.append(
+                    f"COPY/ADD source '{src}' not found in build context"
+                )
+    return errors
+
+
+def validate_dockerfile(
+    content: str, context_files: Optional[Set[str]] = None
+) -> DockerfileValidationResult:
     """
     Validate a Dockerfile for qBraid kernel compatibility.
 
@@ -153,6 +228,9 @@ def validate_dockerfile(content: str) -> DockerfileValidationResult:
     5. No --privileged flags
     6. kernel.json is copied or created
     7. Kernel name matches naming pattern
+    8. COPY/ADD sources exist in the packaged build context (when
+       ``context_files`` is provided — the set of names returned by
+       ``context_files.list_context_files``).
     """
     result = DockerfileValidationResult()
 
@@ -226,13 +304,28 @@ def validate_dockerfile(content: str) -> DockerfileValidationResult:
             "It should be placed under /usr/local/share/jupyter/kernels/<name>/"
         )
 
+    # 7. When the caller provided the packaged context, verify every
+    #    COPY/ADD source resolves. Catches the class of failure where a
+    #    user's Dockerfile says `COPY pyproject.toml ./` but the file
+    #    wasn't included in the upload — would otherwise fail minutes
+    #    later inside Cloud Build with a useless tarball error.
+    if context_files is not None:
+        for error in _check_copy_add_sources(lines, context_files):
+            result.add_error(error)
+
     return result
 
 
-def validate_dockerfile_file(dockerfile_path: str) -> None:
+def validate_dockerfile_file(
+    dockerfile_path: str, context_dir: Optional[str] = None
+) -> None:
     """
     Validate a Dockerfile from a file path.
     Exits with code 1 on validation failure.
+
+    When ``context_dir`` is provided, also enforces that every COPY/ADD
+    source in the Dockerfile exists in the packaged context (the set of
+    files that would actually reach Cloud Build, per ``list_context_files``).
     """
     path = Path(dockerfile_path)
     if not path.exists():
@@ -240,7 +333,11 @@ def validate_dockerfile_file(dockerfile_path: str) -> None:
         sys.exit(1)
 
     content = path.read_text()
-    result = validate_dockerfile(content)
+    context_files: Optional[Set[str]] = None
+    if context_dir is not None:
+        context_files = list_context_files(Path(context_dir), path)
+
+    result = validate_dockerfile(content, context_files=context_files)
 
     if not result.is_valid:
         logger.error("Dockerfile validation failed:")
@@ -253,6 +350,9 @@ def validate_dockerfile_file(dockerfile_path: str) -> None:
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        logger.error("Usage: python validate_dockerfile.py <dockerfile_path>")
+        logger.error(
+            "Usage: python validate_dockerfile.py <dockerfile_path> [<context_dir>]"
+        )
         sys.exit(1)
-    validate_dockerfile_file(sys.argv[1])
+    ctx = sys.argv[2] if len(sys.argv) >= 3 else None
+    validate_dockerfile_file(sys.argv[1], ctx)

--- a/src/scripts/validate_dockerfile.py
+++ b/src/scripts/validate_dockerfile.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from common import Config
-from common import ValidationError as ActionValidationError
 from common import setup_logging
 
 logger = setup_logging(__name__)

--- a/src/scripts/validate_dockerfile.py
+++ b/src/scripts/validate_dockerfile.py
@@ -181,9 +181,7 @@ def _parse_copy_add_sources(line: str) -> Optional[List[str]]:
     return tokens[:-1]
 
 
-def _check_copy_add_sources(
-    lines: List[str], available: Set[str]
-) -> List[str]:
+def _check_copy_add_sources(lines: List[str], available: Set[str]) -> List[str]:
     """Errors for COPY/ADD source paths missing from the packaged context.
 
     URLs and `${VAR}` build-arg interpolations are skipped — the former
@@ -208,9 +206,7 @@ def _check_copy_add_sources(
             normalized = src.lstrip("./")
             top = normalized.split("/", 1)[0]
             if top and top not in available:
-                errors.append(
-                    f"COPY/ADD source '{src}' not found in build context"
-                )
+                errors.append(f"COPY/ADD source '{src}' not found in build context")
     return errors
 
 

--- a/src/scripts/validate_dockerfile.py
+++ b/src/scripts/validate_dockerfile.py
@@ -1,0 +1,256 @@
+# Copyright (C) 2026 qBraid
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from common import Config, setup_logging
+from common import ValidationError as ActionValidationError
+
+logger = setup_logging(__name__)
+
+KERNEL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{2,63}$")
+
+SUPPORTED_LANGUAGES = frozenset(
+    {"python", "cpp", "julia", "r", "rust", "go", "javascript"}
+)
+
+REQUIRED_LABELS = frozenset(
+    {"qbraid.kernel.name", "qbraid.kernel.language", "qbraid.kernel.display_name"}
+)
+
+
+@dataclass
+class DockerfileValidationResult:
+    """Collects validation errors for a Dockerfile."""
+
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+    def add_error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+
+def _parse_labels(lines: List[str]) -> Dict[str, str]:
+    """Extract LABEL directives from Dockerfile lines."""
+    labels: Dict[str, str] = {}
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.upper().startswith("LABEL "):
+            continue
+        # Handle both LABEL key=value and LABEL key="value"
+        content = stripped[6:].strip()
+        # Split on whitespace for multi-label lines
+        parts = re.findall(r'(\S+?)=("[^"]*"|\S+)', content)
+        for key, value in parts:
+            labels[key] = value.strip('"')
+    return labels
+
+
+def _get_final_user(lines: List[str]) -> Optional[str]:
+    """Get the last USER directive in the Dockerfile."""
+    last_user = None
+    for line in lines:
+        stripped = line.strip()
+        if stripped.upper().startswith("USER "):
+            last_user = stripped[5:].strip()
+    return last_user
+
+
+def _has_expose_8888(lines: List[str]) -> bool:
+    """Check if EXPOSE 8888 is present."""
+    for line in lines:
+        stripped = line.strip()
+        if stripped.upper().startswith("EXPOSE "):
+            ports = stripped[7:].strip().split()
+            if "8888" in ports or "8888/tcp" in ports:
+                return True
+    return False
+
+
+def _get_cmd_or_entrypoint(lines: List[str]) -> Optional[str]:
+    """Get the last CMD or ENTRYPOINT directive."""
+    last_cmd = None
+    for line in lines:
+        stripped = line.strip()
+        upper = stripped.upper()
+        if upper.startswith("CMD ") or upper.startswith("ENTRYPOINT "):
+            last_cmd = stripped
+    return last_cmd
+
+
+def _has_kernel_json_copy(lines: List[str]) -> bool:
+    """Check if kernel.json is being copied into the image."""
+    for line in lines:
+        stripped = line.strip()
+        upper = stripped.upper()
+        if upper.startswith("COPY ") or upper.startswith("ADD "):
+            if "kernel.json" in stripped:
+                return True
+        # Also check RUN commands that create kernel.json
+        if upper.startswith("RUN "):
+            if "kernel.json" in stripped and (
+                "echo" in stripped.lower()
+                or "cat" in stripped.lower()
+                or "tee" in stripped.lower()
+                or "kernelspec" in stripped.lower()
+            ):
+                return True
+    return False
+
+
+def _has_privileged_flags(lines: List[str]) -> bool:
+    """Check for privileged operation flags."""
+    for line in lines:
+        stripped = line.strip()
+        if "--privileged" in stripped or "--cap-add=SYS_ADMIN" in stripped:
+            return True
+    return False
+
+
+def _join_continuation_lines(raw_lines: List[str]) -> List[str]:
+    """Join lines that end with backslash continuation."""
+    joined: List[str] = []
+    current = ""
+    for line in raw_lines:
+        stripped = line.rstrip()
+        # Skip comments
+        if stripped.lstrip().startswith("#"):
+            continue
+        if stripped.endswith("\\"):
+            current += stripped[:-1] + " "
+        else:
+            current += stripped
+            if current.strip():
+                joined.append(current)
+            current = ""
+    if current.strip():
+        joined.append(current)
+    return joined
+
+
+def validate_dockerfile(content: str) -> DockerfileValidationResult:
+    """
+    Validate a Dockerfile for qBraid kernel compatibility.
+
+    Checks:
+    1. Required LABEL directives (qbraid.kernel.name, language, display_name)
+    2. EXPOSE 8888 present
+    3. CMD/ENTRYPOINT references jupyter kernelgateway
+    4. Final USER is not root
+    5. No --privileged flags
+    6. kernel.json is copied or created
+    7. Kernel name matches naming pattern
+    """
+    result = DockerfileValidationResult()
+
+    if not content.strip():
+        result.add_error("Dockerfile is empty")
+        return result
+
+    raw_lines = content.splitlines()
+    lines = _join_continuation_lines(raw_lines)
+
+    if not lines:
+        result.add_error("Dockerfile contains no instructions")
+        return result
+
+    # 1. Check required LABEL directives
+    labels = _parse_labels(lines)
+    for required_label in REQUIRED_LABELS:
+        if required_label not in labels:
+            result.add_error(f'Missing required LABEL: {required_label}')
+
+    # 1a. Validate kernel name format
+    kernel_name = labels.get("qbraid.kernel.name", "")
+    if kernel_name and not KERNEL_NAME_PATTERN.match(kernel_name):
+        result.add_error(
+            f'LABEL qbraid.kernel.name "{kernel_name}" is invalid. '
+            "Must start with a lowercase letter and contain only lowercase letters, "
+            "digits, and underscores (3-64 chars)"
+        )
+
+    # 1b. Validate language
+    language = labels.get("qbraid.kernel.language", "")
+    if language and language not in SUPPORTED_LANGUAGES:
+        result.add_error(
+            f'LABEL qbraid.kernel.language "{language}" is not supported. '
+            f"Supported: {', '.join(sorted(SUPPORTED_LANGUAGES))}"
+        )
+
+    # 1c. Validate display name is non-empty
+    display_name = labels.get("qbraid.kernel.display_name", "")
+    if "qbraid.kernel.display_name" in labels and not display_name:
+        result.add_error("LABEL qbraid.kernel.display_name cannot be empty")
+
+    # 2. Check EXPOSE 8888
+    if not _has_expose_8888(lines):
+        result.add_error("Missing EXPOSE 8888 (required for kernel gateway)")
+
+    # 3. Check CMD/ENTRYPOINT references jupyter kernelgateway
+    cmd = _get_cmd_or_entrypoint(lines)
+    if cmd is None:
+        result.add_error(
+            "Missing CMD or ENTRYPOINT. Must reference 'jupyter kernelgateway'"
+        )
+    elif "kernelgateway" not in cmd.lower() and "kernel_gateway" not in cmd.lower():
+        result.add_error(
+            "CMD/ENTRYPOINT must reference 'jupyter kernelgateway'. "
+            f"Found: {cmd}"
+        )
+
+    # 4. Final USER must not be root
+    final_user = _get_final_user(lines)
+    if final_user and final_user.lower() in ("root", "0"):
+        result.add_error(
+            "Final USER directive must not be root (security requirement)"
+        )
+
+    # 5. No privileged flags
+    if _has_privileged_flags(lines):
+        result.add_error(
+            "Dockerfile must not use --privileged or --cap-add=SYS_ADMIN"
+        )
+
+    # 6. kernel.json must be copied or created
+    if not _has_kernel_json_copy(lines):
+        result.add_error(
+            "kernel.json must be COPY'd, ADD'd, or created via RUN in the Dockerfile. "
+            "It should be placed under /usr/local/share/jupyter/kernels/<name>/"
+        )
+
+    return result
+
+
+def validate_dockerfile_file(dockerfile_path: str) -> None:
+    """
+    Validate a Dockerfile from a file path.
+    Exits with code 1 on validation failure.
+    """
+    path = Path(dockerfile_path)
+    if not path.exists():
+        logger.error(f"Dockerfile not found: {path}")
+        sys.exit(1)
+
+    content = path.read_text()
+    result = validate_dockerfile(content)
+
+    if not result.is_valid:
+        logger.error("Dockerfile validation failed:")
+        for error in result.errors:
+            logger.error(f"  - {error}")
+        sys.exit(1)
+
+    logger.info("Dockerfile validation passed")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        logger.error("Usage: python validate_dockerfile.py <dockerfile_path>")
+        sys.exit(1)
+    validate_dockerfile_file(sys.argv[1])

--- a/src/scripts/validate_dockerfile.py
+++ b/src/scripts/validate_dockerfile.py
@@ -169,7 +169,7 @@ def validate_dockerfile(content: str) -> DockerfileValidationResult:
 
     # 1. Check required LABEL directives
     labels = _parse_labels(lines)
-    for required_label in REQUIRED_LABELS:
+    for required_label in sorted(REQUIRED_LABELS):
         if required_label not in labels:
             result.add_error(f"Missing required LABEL: {required_label}")
 

--- a/src/scripts/validate_dockerfile.py
+++ b/src/scripts/validate_dockerfile.py
@@ -51,6 +51,11 @@ def _parse_labels(lines: List[str]) -> Dict[str, str]:
     return labels
 
 
+def extract_dockerfile_labels(content: str) -> Dict[str, str]:
+    """Extract LABEL directives from raw Dockerfile content."""
+    return _parse_labels(_join_continuation_lines(content.splitlines()))
+
+
 def _get_final_user(lines: List[str]) -> Optional[str]:
     """Get the last USER directive in the Dockerfile."""
     last_user = None
@@ -87,6 +92,7 @@ def _has_kernel_json_copy(lines: List[str]) -> bool:
     """Check if kernel.json is being copied into the image."""
     for line in lines:
         stripped = line.strip()
+        lowered = stripped.lower()
         upper = stripped.upper()
         if upper.startswith("COPY ") or upper.startswith("ADD "):
             if "kernel.json" in stripped:
@@ -94,11 +100,13 @@ def _has_kernel_json_copy(lines: List[str]) -> bool:
         # Also check RUN commands that create kernel.json
         if upper.startswith("RUN "):
             if "kernel.json" in stripped and (
-                "echo" in stripped.lower()
-                or "cat" in stripped.lower()
-                or "tee" in stripped.lower()
-                or "kernelspec" in stripped.lower()
+                "echo" in lowered
+                or "cat" in lowered
+                or "tee" in lowered
+                or "kernelspec" in lowered
             ):
+                return True
+            if "ipykernel" in lowered and "install" in lowered:
                 return True
     return False
 

--- a/src/scripts/validate_dockerfile.py
+++ b/src/scripts/validate_dockerfile.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from common import Config, setup_logging
+from common import Config
 from common import ValidationError as ActionValidationError
+from common import setup_logging
 
 logger = setup_logging(__name__)
 
@@ -164,7 +165,7 @@ def validate_dockerfile(content: str) -> DockerfileValidationResult:
     labels = _parse_labels(lines)
     for required_label in REQUIRED_LABELS:
         if required_label not in labels:
-            result.add_error(f'Missing required LABEL: {required_label}')
+            result.add_error(f"Missing required LABEL: {required_label}")
 
     # 1a. Validate kernel name format
     kernel_name = labels.get("qbraid.kernel.name", "")
@@ -200,22 +201,17 @@ def validate_dockerfile(content: str) -> DockerfileValidationResult:
         )
     elif "kernelgateway" not in cmd.lower() and "kernel_gateway" not in cmd.lower():
         result.add_error(
-            "CMD/ENTRYPOINT must reference 'jupyter kernelgateway'. "
-            f"Found: {cmd}"
+            "CMD/ENTRYPOINT must reference 'jupyter kernelgateway'. " f"Found: {cmd}"
         )
 
     # 4. Final USER must not be root
     final_user = _get_final_user(lines)
     if final_user and final_user.lower() in ("root", "0"):
-        result.add_error(
-            "Final USER directive must not be root (security requirement)"
-        )
+        result.add_error("Final USER directive must not be root (security requirement)")
 
     # 5. No privileged flags
     if _has_privileged_flags(lines):
-        result.add_error(
-            "Dockerfile must not use --privileged or --cap-add=SYS_ADMIN"
-        )
+        result.add_error("Dockerfile must not use --privileged or --cap-add=SYS_ADMIN")
 
     # 6. kernel.json must be copied or created
     if not _has_kernel_json_copy(lines):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -93,8 +93,8 @@ def sample_course_json():
                 "chapterFileName": "chapter1.ipynb.json",
                 "baseFilePath": "chapter1.ipynb",
                 "chapterNumber": 1,
-                "kernelName": "python3",
-                "kernelId": "python3",
+                "kernelName": "qbraid_python",
+                "kernelId": "qbraid_python",
                 "sections": [],
             }
         ],

--- a/test/e2e/test_action_flow.py
+++ b/test/e2e/test_action_flow.py
@@ -31,7 +31,6 @@ from common import Config
 
 @pytest.mark.e2e
 class TestActionFlowE2E:
-
     def setup_method(self):
         self.old_cwd = os.getcwd()
         self.test_dir = tempfile.mkdtemp()
@@ -79,8 +78,8 @@ class TestActionFlowE2E:
                     "chapterFileName": "chapter1.ipynb.json",
                     "baseFilePath": "chapter1.ipynb",
                     "chapterNumber": 1,
-                    "kernelName": "python3",
-                    "kernelId": "python3",
+                    "kernelName": "qbraid_python",
+                    "kernelId": "qbraid_python",
                     "sections": [],
                 }
             ],
@@ -98,7 +97,6 @@ class TestActionFlowE2E:
             mock.patch("deploy_common.QbraidSessionV1") as mock_session_cls_create,
             mock.patch("poll_files_progress.QbraidSessionV1") as mock_session_cls_poll,
         ):
-
             # Configure mock instances
             mock_session_instance_validate = mock_session_cls_validate.return_value
             mock_session_instance_create = mock_session_cls_create.return_value

--- a/test/e2e/test_nasty_inputs.py
+++ b/test/e2e/test_nasty_inputs.py
@@ -134,8 +134,8 @@ class TestNastyInputs:
                 "chapterFileName": "missing.ipynb.json",
                 "baseFilePath": "nonexistent.ipynb",
                 "chapterNumber": 1,
-                "kernelName": "python3",
-                "kernelId": "python3",
+                "kernelName": "qbraid_python",
+                "kernelId": "qbraid_python",
                 "sections": [],
             }
         ]
@@ -186,8 +186,8 @@ class TestNastyInputs:
                 "chapterFileName": "traversal.ipynb.json",
                 "baseFilePath": "../../../etc/passwd",
                 "chapterNumber": 1,
-                "kernelName": "python3",
-                "kernelId": "python3",
+                "kernelName": "qbraid_python",
+                "kernelId": "qbraid_python",
                 "sections": [],
             }
         ]

--- a/test/unit/test_deploy_kernel.py
+++ b/test/unit/test_deploy_kernel.py
@@ -735,7 +735,9 @@ CMD ["jupyter", "kernelgateway"]
     def test_deploy_kernel_rejects_label_mismatch(self, tmp_path):
         dockerfile_path = tmp_path / "Dockerfile"
         dockerfile_path.write_text(
-            self.valid_dockerfile.replace('qbraid.kernel.name="test_kernel"', 'qbraid.kernel.name="other_kernel"')
+            self.valid_dockerfile.replace(
+                'qbraid.kernel.name="test_kernel"', 'qbraid.kernel.name="other_kernel"'
+            )
         )
 
         with pytest.raises(SystemExit) as exc_info:

--- a/test/unit/test_deploy_kernel.py
+++ b/test/unit/test_deploy_kernel.py
@@ -1,28 +1,43 @@
 # Copyright (C) 2026 qBraid
 
 import base64
-import json
+import importlib.util
 import sys
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-sys.path.insert(
-    0, str(Path(__file__).parent.parent.parent / "deploy-kernel" / "src" / "scripts")
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+DEPLOY_KERNEL_PATH = (
+    PROJECT_ROOT / "deploy-kernel" / "src" / "scripts" / "deploy_kernel.py"
 )
-from deploy_kernel import (
-    FATAL_POLL_STATUS_CODES,
-    KERNEL_ALREADY_EXISTS_CODE,
-    MAX_POLL_ATTEMPTS,
-    POLL_INTERVAL_SECONDS,
-    REQUEST_TIMEOUT_SECONDS,
-    _collect_context_files,
-    _encode_file,
-    _parse_error_response,
-    deploy_kernel,
-    write_github_output,
-)
+
+
+def _load_deploy_kernel_module():
+    spec = importlib.util.spec_from_file_location("deploy_kernel", DEPLOY_KERNEL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    sys.path.insert(0, str(DEPLOY_KERNEL_PATH.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+deploy_kernel_module = _load_deploy_kernel_module()
+FATAL_POLL_STATUS_CODES = deploy_kernel_module.FATAL_POLL_STATUS_CODES
+KERNEL_ALREADY_EXISTS_CODE = deploy_kernel_module.KERNEL_ALREADY_EXISTS_CODE
+MAX_POLL_ATTEMPTS = deploy_kernel_module.MAX_POLL_ATTEMPTS
+POLL_INTERVAL_SECONDS = deploy_kernel_module.POLL_INTERVAL_SECONDS
+REQUEST_TIMEOUT_SECONDS = deploy_kernel_module.REQUEST_TIMEOUT_SECONDS
+_collect_context_files = deploy_kernel_module._collect_context_files
+_encode_file = deploy_kernel_module._encode_file
+_parse_error_response = deploy_kernel_module._parse_error_response
+deploy_kernel = deploy_kernel_module.deploy_kernel
+write_github_output = deploy_kernel_module.write_github_output
 
 
 @pytest.mark.unit

--- a/test/unit/test_deploy_kernel.py
+++ b/test/unit/test_deploy_kernel.py
@@ -12,6 +12,7 @@ sys.path.insert(
     0, str(Path(__file__).parent.parent.parent / "deploy-kernel" / "src" / "scripts")
 )
 from deploy_kernel import (
+    FATAL_POLL_STATUS_CODES,
     KERNEL_ALREADY_EXISTS_CODE,
     MAX_POLL_ATTEMPTS,
     POLL_INTERVAL_SECONDS,
@@ -36,6 +37,9 @@ class TestConstants:
 
     def test_request_timeout(self):
         assert REQUEST_TIMEOUT_SECONDS == 30
+
+    def test_fatal_poll_status_codes(self):
+        assert FATAL_POLL_STATUS_CODES == {400, 401, 403, 404}
 
 
 @pytest.mark.unit
@@ -516,6 +520,87 @@ CMD ["jupyter", "kernelgateway"]
 
         post_call = mock_post.call_args
         assert custom_url in post_call[0][0]
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_poll_build_not_found_fails_fast(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        missing_response = mock.Mock()
+        missing_response.status_code = 404
+        missing_response.text = "build missing"
+        missing_response.json.return_value = {
+            "success": False,
+            "error": {
+                "code": "BUILD_NOT_FOUND",
+                "message": "Build 'build-123' not found",
+            },
+        }
+        mock_get.return_value = missing_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+
+        assert exc_info.value.code == 1
+        assert mock_get.call_count == 1
+        mock_write_output.assert_any_call("status", "failed")
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_poll_auth_failure_fails_fast(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        unauthorized_response = mock.Mock()
+        unauthorized_response.status_code = 401
+        unauthorized_response.text = "Unauthorized"
+        unauthorized_response.json.return_value = {
+            "success": False,
+            "error": {"code": "UNAUTHORIZED", "message": "Invalid API key"},
+        }
+        mock_get.return_value = unauthorized_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+
+        assert exc_info.value.code == 1
+        assert mock_get.call_count == 1
+        mock_write_output.assert_any_call("status", "failed")
 
     @mock.patch("deploy_kernel.time.sleep")
     @mock.patch("deploy_kernel.write_github_output")

--- a/test/unit/test_deploy_kernel.py
+++ b/test/unit/test_deploy_kernel.py
@@ -87,6 +87,16 @@ class TestWriteGithubOutput:
         lines = content.strip().split("\n")
         assert len(lines) == 2
 
+    def test_write_multiline_output_uses_delimiter_format(self, tmp_path, monkeypatch):
+        output_file = tmp_path / "github_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+        write_github_output("error", "first line\nsecond line")
+
+        content = output_file.read_text()
+        assert "error<<" in content
+        assert "first line\nsecond line" in content
+
 
 @pytest.mark.unit
 class TestEncodeFile:
@@ -140,6 +150,19 @@ class TestCollectContextFiles:
 
         result = _collect_context_files(tmp_path, dockerfile_path)
         assert ".gitignore" not in result
+
+    def test_collect_context_files_excludes_sensitive_files(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.touch()
+        (tmp_path / ".env").write_text("QBRAID_API_KEY=secret")
+        (tmp_path / "secrets.pem").write_text("pem")
+        (tmp_path / "requirements.txt").write_text("requests")
+
+        result = _collect_context_files(tmp_path, dockerfile_path)
+
+        assert ".env" not in result
+        assert "secrets.pem" not in result
+        assert "requirements.txt" in result
 
     def test_collect_context_files_skips_large_files(self, tmp_path):
         dockerfile_path = tmp_path / "Dockerfile"
@@ -233,6 +256,7 @@ CMD ["jupyter", "kernelgateway"]
         mock_write_output.assert_any_call("kernel-name", "test_kernel")
         mock_write_output.assert_any_call("status", "active")
         mock_write_output.assert_any_call("image-uri", "docker.io/image:tag")
+        mock_sleep.assert_not_called()
 
     @mock.patch("deploy_kernel.write_github_output")
     def test_deploy_kernel_missing_dockerfile(self, mock_write_output, tmp_path):
@@ -240,13 +264,13 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="test-key",
                 dockerfile_path=nonexistent_path,
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="test-key",
             )
         assert exc_info.value.code == 1
 
@@ -263,13 +287,13 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="bad-key",
                 dockerfile_path=str(dockerfile_path),
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="bad-key",
             )
         assert exc_info.value.code == 1
 
@@ -294,13 +318,13 @@ CMD ["jupyter", "kernelgateway"]
         mock_post.return_value = mock_post_response
 
         deploy_kernel(
-            api_key="test-key",
             dockerfile_path=str(dockerfile_path),
             kernel_name="test_kernel",
             language="python",
             display_name="Test Kernel",
             context_dir=str(tmp_path),
             api_base_url="https://api.qbraid.com",
+            api_key="test-key",
         )
 
         mock_write_output.assert_any_call("kernel-name", "test_kernel")
@@ -319,13 +343,13 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="test-key",
                 dockerfile_path=str(dockerfile_path),
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="test-key",
             )
         assert exc_info.value.code == 1
 
@@ -359,13 +383,13 @@ CMD ["jupyter", "kernelgateway"]
         mock_get.side_effect = mock_get_responses
 
         deploy_kernel(
-            api_key="test-key",
             dockerfile_path=str(dockerfile_path),
             kernel_name="test_kernel",
             language="python",
             display_name="Test Kernel",
             context_dir=str(tmp_path),
             api_base_url="https://api.qbraid.com",
+            api_key="test-key",
         )
 
         assert mock_get.call_count == 4
@@ -395,13 +419,13 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="test-key",
                 dockerfile_path=str(dockerfile_path),
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="test-key",
             )
         assert exc_info.value.code == 1
         mock_write_output.assert_any_call("status", "failed")
@@ -463,13 +487,13 @@ CMD ["jupyter", "kernelgateway"]
         mock_get.return_value = mock_get_response
 
         deploy_kernel(
-            api_key="test-key",
             dockerfile_path=str(dockerfile_path),
             kernel_name="test_kernel",
             language="python",
             display_name="Test Kernel",
             context_dir=str(tmp_path),
             api_base_url="https://api.qbraid.com",
+            api_key="test-key",
         )
 
         assert mock_post.called
@@ -492,13 +516,13 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="test-key",
                 dockerfile_path=str(dockerfile_path),
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="test-key",
             )
         assert exc_info.value.code == 1
 
@@ -524,13 +548,13 @@ CMD ["jupyter", "kernelgateway"]
 
         custom_url = "https://custom-api.qbraid.com/api/v1"
         deploy_kernel(
-            api_key="test-key",
             dockerfile_path=str(dockerfile_path),
             kernel_name="test_kernel",
             language="python",
             display_name="Test Kernel",
             context_dir=str(tmp_path),
             api_base_url=custom_url,
+            api_key="test-key",
         )
 
         post_call = mock_post.call_args
@@ -565,13 +589,13 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="test-key",
                 dockerfile_path=str(dockerfile_path),
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="test-key",
             )
 
         assert exc_info.value.code == 1
@@ -604,13 +628,13 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="test-key",
                 dockerfile_path=str(dockerfile_path),
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="test-key",
             )
 
         assert exc_info.value.code == 1
@@ -648,16 +672,84 @@ CMD ["jupyter", "kernelgateway"]
 
         with pytest.raises(SystemExit) as exc_info:
             deploy_kernel(
-                api_key="test-key",
                 dockerfile_path=str(dockerfile_path),
                 kernel_name="test_kernel",
                 language="python",
                 display_name="Test Kernel",
                 context_dir=str(tmp_path),
                 api_base_url="https://api.qbraid.com",
+                api_key="test-key",
             )
         assert exc_info.value.code == 1
         mock_write_output.assert_any_call("status", "timeout")
+
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    def test_deploy_kernel_uses_api_key_from_env(
+        self, mock_post, mock_write_output, tmp_path, monkeypatch
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+        monkeypatch.setenv("QBRAID_API_KEY", "env-api-key")
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 400
+        mock_post_response.text = "Kernel already exists"
+        mock_post_response.json.return_value = {
+            "error": {
+                "message": "Kernel 'test_kernel' already exists",
+                "code": KERNEL_ALREADY_EXISTS_CODE,
+            }
+        }
+        mock_post.return_value = mock_post_response
+
+        deploy_kernel(
+            dockerfile_path=str(dockerfile_path),
+            kernel_name="test_kernel",
+            language="python",
+            display_name="Test Kernel",
+            context_dir=str(tmp_path),
+            api_base_url="https://api.qbraid.com",
+        )
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["X-API-Key"] == "env-api-key"
+
+    def test_deploy_kernel_rejects_invalid_kernel_name(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="Invalid-Name",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+                api_key="test-key",
+            )
+
+        assert exc_info.value.code == 1
+
+    def test_deploy_kernel_rejects_label_mismatch(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(
+            self.valid_dockerfile.replace('qbraid.kernel.name="test_kernel"', 'qbraid.kernel.name="other_kernel"')
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+                api_key="test-key",
+            )
+
+        assert exc_info.value.code == 1
 
 
 @pytest.mark.unit

--- a/test/unit/test_deploy_kernel.py
+++ b/test/unit/test_deploy_kernel.py
@@ -12,11 +12,13 @@ sys.path.insert(
     0, str(Path(__file__).parent.parent.parent / "deploy-kernel" / "src" / "scripts")
 )
 from deploy_kernel import (
+    KERNEL_ALREADY_EXISTS_CODE,
     MAX_POLL_ATTEMPTS,
     POLL_INTERVAL_SECONDS,
     REQUEST_TIMEOUT_SECONDS,
     _collect_context_files,
     _encode_file,
+    _parse_error_response,
     deploy_kernel,
     write_github_output,
 )
@@ -254,6 +256,39 @@ CMD ["jupyter", "kernelgateway"]
 
     @mock.patch("deploy_kernel.write_github_output")
     @mock.patch("deploy_kernel.requests.post")
+    def test_deploy_kernel_already_exists_is_treated_as_success(
+        self, mock_post, mock_write_output, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 400
+        mock_post_response.text = "Kernel already exists"
+        mock_post_response.json.return_value = {
+            "success": False,
+            "error": {
+                "message": "Kernel 'test_kernel' already exists with status 'active'",
+                "code": KERNEL_ALREADY_EXISTS_CODE,
+            },
+        }
+        mock_post.return_value = mock_post_response
+
+        deploy_kernel(
+            api_key="test-key",
+            dockerfile_path=str(dockerfile_path),
+            kernel_name="test_kernel",
+            language="python",
+            display_name="Test Kernel",
+            context_dir=str(tmp_path),
+            api_base_url="https://api.qbraid.com",
+        )
+
+        mock_write_output.assert_any_call("kernel-name", "test_kernel")
+        mock_write_output.assert_any_call("status", "active")
+
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
     def test_deploy_kernel_no_build_id(self, mock_post, mock_write_output, tmp_path):
         dockerfile_path = tmp_path / "Dockerfile"
         dockerfile_path.write_text(self.valid_dockerfile)
@@ -384,7 +419,6 @@ CMD ["jupyter", "kernelgateway"]
             )
         assert exc_info.value.code == 1
         mock_write_output.assert_any_call("status", "timeout")
-        assert mock_get.call_count == MAX_POLL_ATTEMPTS
 
     @mock.patch("deploy_kernel.time.sleep")
     @mock.patch("deploy_kernel.write_github_output")
@@ -524,3 +558,28 @@ CMD ["jupyter", "kernelgateway"]
             )
         assert exc_info.value.code == 1
         mock_write_output.assert_any_call("status", "timeout")
+
+
+@pytest.mark.unit
+class TestParseErrorResponse:
+    def test_prefers_structured_error_payload(self):
+        response = mock.Mock()
+        response.text = "fallback"
+        response.json.return_value = {
+            "error": {"code": KERNEL_ALREADY_EXISTS_CODE, "message": "already there"}
+        }
+
+        error_code, message = _parse_error_response(response)
+
+        assert error_code == KERNEL_ALREADY_EXISTS_CODE
+        assert message == "already there"
+
+    def test_falls_back_to_response_text_for_non_json(self):
+        response = mock.Mock()
+        response.text = "plain text error"
+        response.json.side_effect = ValueError("invalid json")
+
+        error_code, message = _parse_error_response(response)
+
+        assert error_code is None
+        assert message == "plain text error"

--- a/test/unit/test_deploy_kernel.py
+++ b/test/unit/test_deploy_kernel.py
@@ -1,0 +1,526 @@
+# Copyright (C) 2026 qBraid
+
+import base64
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).parent.parent.parent / "deploy-kernel" / "src" / "scripts")
+)
+from deploy_kernel import (
+    MAX_POLL_ATTEMPTS,
+    POLL_INTERVAL_SECONDS,
+    REQUEST_TIMEOUT_SECONDS,
+    _collect_context_files,
+    _encode_file,
+    deploy_kernel,
+    write_github_output,
+)
+
+
+@pytest.mark.unit
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_max_poll_attempts(self):
+        assert MAX_POLL_ATTEMPTS == 60
+
+    def test_poll_interval(self):
+        assert POLL_INTERVAL_SECONDS == 30
+
+    def test_request_timeout(self):
+        assert REQUEST_TIMEOUT_SECONDS == 30
+
+
+@pytest.mark.unit
+class TestWriteGithubOutput:
+    """Tests for write_github_output function."""
+
+    def test_write_without_github_output_env(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        write_github_output("key", "value")
+
+    def test_write_with_github_output_env(self, tmp_path, monkeypatch):
+        output_file = tmp_path / "github_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+        write_github_output("build-id", "test-build-123")
+        write_github_output("kernel-name", "my_kernel")
+
+        content = output_file.read_text()
+        assert "build-id=test-build-123" in content
+        assert "kernel-name=my_kernel" in content
+
+    def test_write_multiple_outputs(self, tmp_path, monkeypatch):
+        output_file = tmp_path / "github_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+        write_github_output("key1", "value1")
+        write_github_output("key2", "value2")
+
+        content = output_file.read_text()
+        lines = content.strip().split("\n")
+        assert len(lines) == 2
+
+
+@pytest.mark.unit
+class TestEncodeFile:
+    """Tests for _encode_file helper function."""
+
+    def test_encode_simple_file(self, tmp_path):
+        file_path = tmp_path / "test.txt"
+        file_path.write_text("Hello, World!")
+
+        encoded = _encode_file(file_path)
+        assert isinstance(encoded, str)
+        decoded = base64.b64decode(encoded)
+        assert decoded == b"Hello, World!"
+
+    def test_encode_empty_file(self, tmp_path):
+        file_path = tmp_path / "empty.txt"
+        file_path.write_text("")
+
+        encoded = _encode_file(file_path)
+        assert encoded == ""
+
+
+@pytest.mark.unit
+class TestCollectContextFiles:
+    """Tests for _collect_context_files helper function."""
+
+    def test_collect_from_empty_dir(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.touch()
+
+        result = _collect_context_files(tmp_path, dockerfile_path)
+        assert result == {}
+
+    def test_collect_context_files_excludes_dockerfile(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text("FROM python:3.11")
+
+        test_file = tmp_path / "requirements.txt"
+        test_file.write_text("requests")
+
+        result = _collect_context_files(tmp_path, dockerfile_path)
+        assert "requirements.txt" in result
+        assert "Dockerfile" not in result
+
+    def test_collect_context_files_excludes_gitignore(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.touch()
+
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("*.pyc")
+
+        result = _collect_context_files(tmp_path, dockerfile_path)
+        assert ".gitignore" not in result
+
+    def test_collect_context_files_skips_large_files(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.touch()
+
+        large_file = tmp_path / "large.bin"
+        large_file.write_bytes(b"x" * (11 * 1024 * 1024))
+
+        result = _collect_context_files(tmp_path, dockerfile_path)
+        assert "large.bin" not in result
+
+    def test_collect_nested_files(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.touch()
+
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        (subdir / "file.txt").write_text("content")
+
+        result = _collect_context_files(tmp_path, dockerfile_path)
+        assert "subdir/file.txt" not in result
+
+    def test_collect_single_level_files(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.touch()
+
+        file1 = tmp_path / "file1.txt"
+        file1.write_text("content1")
+        file2 = tmp_path / "file2.txt"
+        file2.write_text("content2")
+
+        result = _collect_context_files(tmp_path, dockerfile_path)
+        assert "file1.txt" in result
+        assert "file2.txt" in result
+
+    def test_collect_nonexistent_dir(self):
+        result = _collect_context_files(Path("/nonexistent"), Path("Dockerfile"))
+        assert result == {}
+
+
+@pytest.mark.unit
+class TestDeployKernel:
+    """Tests for deploy_kernel function."""
+
+    def setup_method(self):
+        self.valid_dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="test_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="Test Kernel"
+EXPOSE 8888
+COPY kernel.json /usr/local/share/jupyter/kernels/test_kernel/
+CMD ["jupyter", "kernelgateway"]
+"""
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_success(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        mock_get_response_active = mock.Mock()
+        mock_get_response_active.status_code = 200
+        mock_get_response_active.json.return_value = {
+            "data": {"status": "active", "imageUri": "docker.io/image:tag"}
+        }
+        mock_get.return_value = mock_get_response_active
+
+        deploy_kernel(
+            api_key="test-key",
+            dockerfile_path=str(dockerfile_path),
+            kernel_name="test_kernel",
+            language="python",
+            display_name="Test Kernel",
+            context_dir=str(tmp_path),
+            api_base_url="https://api.qbraid.com",
+        )
+
+        mock_post.assert_called_once()
+        mock_get.assert_called_once()
+        mock_write_output.assert_any_call("build-id", "build-123")
+        mock_write_output.assert_any_call("kernel-name", "test_kernel")
+        mock_write_output.assert_any_call("status", "active")
+        mock_write_output.assert_any_call("image-uri", "docker.io/image:tag")
+
+    @mock.patch("deploy_kernel.write_github_output")
+    def test_deploy_kernel_missing_dockerfile(self, mock_write_output, tmp_path):
+        nonexistent_path = str(tmp_path / "nonexistent" / "Dockerfile")
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=nonexistent_path,
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+        assert exc_info.value.code == 1
+
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    def test_deploy_kernel_api_error(self, mock_post, mock_write_output, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 401
+        mock_post_response.text = "Unauthorized"
+        mock_post.return_value = mock_post_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="bad-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+        assert exc_info.value.code == 1
+
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    def test_deploy_kernel_no_build_id(self, mock_post, mock_write_output, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {}}
+        mock_post.return_value = mock_post_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+        assert exc_info.value.code == 1
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_polls_until_active(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        mock_get_responses = []
+        for _ in range(3):
+            pending_response = mock.Mock()
+            pending_response.status_code = 200
+            pending_response.json.return_value = {"data": {"status": "pending"}}
+            mock_get_responses.append(pending_response)
+
+        active_response = mock.Mock()
+        active_response.status_code = 200
+        active_response.json.return_value = {"data": {"status": "active"}}
+        mock_get_responses.append(active_response)
+
+        mock_get.side_effect = mock_get_responses
+
+        deploy_kernel(
+            api_key="test-key",
+            dockerfile_path=str(dockerfile_path),
+            kernel_name="test_kernel",
+            language="python",
+            display_name="Test Kernel",
+            context_dir=str(tmp_path),
+            api_base_url="https://api.qbraid.com",
+        )
+
+        assert mock_get.call_count == 4
+        mock_write_output.assert_any_call("status", "active")
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_build_failed(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        failed_response = mock.Mock()
+        failed_response.status_code = 200
+        failed_response.json.return_value = {
+            "data": {"status": "failed", "error": "Build error"}
+        }
+        mock_get.return_value = failed_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+        assert exc_info.value.code == 1
+        mock_write_output.assert_any_call("status", "failed")
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_timeout(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        pending_response = mock.Mock()
+        pending_response.status_code = 200
+        pending_response.json.return_value = {"data": {"status": "pending"}}
+        mock_get.return_value = pending_response
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+        assert exc_info.value.code == 1
+        mock_write_output.assert_any_call("status", "timeout")
+        assert mock_get.call_count == MAX_POLL_ATTEMPTS
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_with_context_files(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        requirements = tmp_path / "requirements.txt"
+        requirements.write_text("jupyter")
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        mock_get_response = mock.Mock()
+        mock_get_response.status_code = 200
+        mock_get_response.json.return_value = {"data": {"status": "active"}}
+        mock_get.return_value = mock_get_response
+
+        deploy_kernel(
+            api_key="test-key",
+            dockerfile_path=str(dockerfile_path),
+            kernel_name="test_kernel",
+            language="python",
+            display_name="Test Kernel",
+            context_dir=str(tmp_path),
+            api_base_url="https://api.qbraid.com",
+        )
+
+        assert mock_post.called
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"]
+        assert "contextFiles" in payload
+        assert "requirements.txt" in payload["contextFiles"]
+
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    def test_deploy_kernel_request_exception(
+        self, mock_post, mock_write_output, tmp_path
+    ):
+        import requests
+
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post.side_effect = requests.RequestException("Connection error")
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+        assert exc_info.value.code == 1
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_explicit_api_base_url(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        mock_get_response = mock.Mock()
+        mock_get_response.status_code = 200
+        mock_get_response.json.return_value = {"data": {"status": "active"}}
+        mock_get.return_value = mock_get_response
+
+        custom_url = "https://custom-api.qbraid.com/api/v1"
+        deploy_kernel(
+            api_key="test-key",
+            dockerfile_path=str(dockerfile_path),
+            kernel_name="test_kernel",
+            language="python",
+            display_name="Test Kernel",
+            context_dir=str(tmp_path),
+            api_base_url=custom_url,
+        )
+
+        post_call = mock_post.call_args
+        assert custom_url in post_call[0][0]
+
+    @mock.patch("deploy_kernel.time.sleep")
+    @mock.patch("deploy_kernel.write_github_output")
+    @mock.patch("deploy_kernel.requests.post")
+    @mock.patch("deploy_kernel.requests.get")
+    def test_deploy_kernel_poll_returns_non_200_continues(
+        self, mock_get, mock_post, mock_write_output, mock_sleep, tmp_path
+    ):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(self.valid_dockerfile)
+
+        mock_post_response = mock.Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"data": {"buildId": "build-123"}}
+        mock_post.return_value = mock_post_response
+
+        pending_response = mock.Mock()
+        pending_response.status_code = 200
+        pending_response.json.return_value = {"data": {"status": "pending"}}
+
+        error_response = mock.Mock()
+        error_response.status_code = 500
+
+        def get_side_effect():
+            yield pending_response
+            while True:
+                yield error_response
+
+        mock_get.side_effect = get_side_effect()
+
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_kernel(
+                api_key="test-key",
+                dockerfile_path=str(dockerfile_path),
+                kernel_name="test_kernel",
+                language="python",
+                display_name="Test Kernel",
+                context_dir=str(tmp_path),
+                api_base_url="https://api.qbraid.com",
+            )
+        assert exc_info.value.code == 1
+        mock_write_output.assert_any_call("status", "timeout")

--- a/test/unit/test_deploy_kernel_validate_dockerfile_wrapper.py
+++ b/test/unit/test_deploy_kernel_validate_dockerfile_wrapper.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 qBraid
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SHARED_VALIDATOR_PATH = PROJECT_ROOT / "src" / "scripts" / "validate_dockerfile.py"
+WRAPPER_VALIDATOR_PATH = (
+    PROJECT_ROOT / "deploy-kernel" / "src" / "scripts" / "validate_dockerfile.py"
+)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    import sys
+
+    sys.path.insert(0, str(path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+@pytest.mark.unit
+def test_deploy_kernel_validator_wrapper_uses_shared_implementation():
+    shared_module = _load_module("shared_validator", SHARED_VALIDATOR_PATH)
+    wrapper_module = _load_module("wrapper_validator", WRAPPER_VALIDATOR_PATH)
+
+    result = wrapper_module.validate_dockerfile(
+        'FROM python:3.11\nLABEL qbraid.kernel.name="bad-name"\n'
+    )
+
+    assert result.errors == shared_module.validate_dockerfile(
+        'FROM python:3.11\nLABEL qbraid.kernel.name="bad-name"\n'
+    ).errors
+    assert (
+        wrapper_module.KERNEL_NAME_PATTERN.pattern
+        == shared_module.KERNEL_NAME_PATTERN.pattern
+    )

--- a/test/unit/test_deploy_kernel_validate_dockerfile_wrapper.py
+++ b/test/unit/test_deploy_kernel_validate_dockerfile_wrapper.py
@@ -15,8 +15,8 @@ WRAPPER_VALIDATOR_PATH = (
 
 def _load_module(name: str, path: Path):
     spec = importlib.util.spec_from_file_location(name, path)
-    module = importlib.util.module_from_spec(spec)
     assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     import sys
 
     sys.path.insert(0, str(path.parent))
@@ -36,9 +36,12 @@ def test_deploy_kernel_validator_wrapper_uses_shared_implementation():
         'FROM python:3.11\nLABEL qbraid.kernel.name="bad-name"\n'
     )
 
-    assert result.errors == shared_module.validate_dockerfile(
-        'FROM python:3.11\nLABEL qbraid.kernel.name="bad-name"\n'
-    ).errors
+    assert (
+        result.errors
+        == shared_module.validate_dockerfile(
+            'FROM python:3.11\nLABEL qbraid.kernel.name="bad-name"\n'
+        ).errors
+    )
     assert (
         wrapper_module.KERNEL_NAME_PATTERN.pattern
         == shared_module.KERNEL_NAME_PATTERN.pattern

--- a/test/unit/test_deploy_kernel_validate_dockerfile_wrapper.py
+++ b/test/unit/test_deploy_kernel_validate_dockerfile_wrapper.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 SHARED_VALIDATOR_PATH = PROJECT_ROOT / "src" / "scripts" / "validate_dockerfile.py"
 WRAPPER_VALIDATOR_PATH = (

--- a/test/unit/test_validate_course.py
+++ b/test/unit/test_validate_course.py
@@ -2,8 +2,12 @@ import json
 from unittest import mock
 
 import pytest
-from common import Config
-from validate_course import Course, CourseValidator
+from validate_course import (
+    Course,
+    CourseValidator,
+    _fetch_available_kernels,
+    _format_missing_kernel_error,
+)
 
 
 @pytest.mark.unit
@@ -72,6 +76,101 @@ class TestCourseValidator:
         with pytest.raises(SystemExit) as e:
             validator.validate()
         assert e.value.code == 1
+
+    @mock.patch.dict("os.environ", {}, clear=False)
+    @mock.patch("validate_course.Path.exists")
+    @mock.patch("validate_course.Path.stat")
+    def test_course_model_skips_catalog_lookup_without_explicit_url(
+        self, mock_stat, mock_exists
+    ):
+        mock_exists.return_value = True
+        mock_stat.return_value.st_size = 100
+
+        valid_data = {
+            "courseName": "Test Course",
+            "courseDescription": "Desc",
+            "visibility": "public",
+            "imageLink": {"darkLogo": "d.png", "lightLogo": "l.png"},
+            "tags": ["tag"],
+            "content": [
+                {
+                    "chapterName": "Ch1",
+                    "chapterFileName": "ch1_file.json",
+                    "baseFilePath": "ch1.ipynb",
+                    "chapterNumber": 1,
+                    "kernelName": "missing_kernel",
+                    "kernelId": "missing_kernel",
+                    "sections": [],
+                }
+            ],
+            "deployedTo": ["qbraid.com"],
+        }
+
+        course = Course(**valid_data)
+        assert course.content[0].kernelName == "missing_kernel"
+
+    @mock.patch.dict(
+        "os.environ",
+        {"KERNEL_CATALOG_URL": "https://example.test/api/kernelspecs"},
+        clear=False,
+    )
+    @mock.patch("validate_course.urllib.request.urlopen")
+    @mock.patch("validate_course.Path.exists")
+    @mock.patch("validate_course.Path.stat")
+    def test_course_model_validates_kernel_name_when_catalog_url_is_set(
+        self, mock_stat, mock_exists, mock_urlopen
+    ):
+        mock_exists.return_value = True
+        mock_stat.return_value.st_size = 100
+        mock_response = mock.Mock()
+        mock_response.read.return_value = json.dumps(
+            {"kernels": {"qbraid_python": {}, "qiskit142_python": {}}}
+        ).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        valid_data = {
+            "courseName": "Test Course",
+            "courseDescription": "Desc",
+            "visibility": "public",
+            "imageLink": {"darkLogo": "d.png", "lightLogo": "l.png"},
+            "tags": ["tag"],
+            "content": [
+                {
+                    "chapterName": "Ch1",
+                    "chapterFileName": "ch1_file.json",
+                    "baseFilePath": "ch1.ipynb",
+                    "chapterNumber": 1,
+                    "kernelName": "missing_kernel",
+                    "kernelId": "missing_kernel",
+                    "sections": [],
+                }
+            ],
+            "deployedTo": ["qbraid.com"],
+        }
+
+        with pytest.raises(Exception) as exc_info:
+            Course(**valid_data)
+
+        assert "Catalog contains 2 kernels" in str(exc_info.value)
+        assert "qbraid_python" in str(exc_info.value)
+        assert "qiskit142_python" in str(exc_info.value)
+
+    @mock.patch("validate_course.urllib.request.urlopen")
+    def test_fetch_available_kernels_returns_none_on_network_errors(self, mock_urlopen):
+        mock_urlopen.side_effect = OSError("network down")
+
+        assert _fetch_available_kernels("https://example.test/api/kernelspecs") is None
+
+    def test_format_missing_kernel_error_limits_kernel_sample(self):
+        available = {f"kernel_{index}" for index in range(20)}
+
+        message = _format_missing_kernel_error(
+            "missing_kernel", "https://example.test/api/kernelspecs", available
+        )
+
+        assert "Catalog contains 20 kernels" in message
+        assert message.count("kernel_") <= 10
+        assert "..." in message
 
     @mock.patch("builtins.open", new_callable=mock.mock_open)
     @mock.patch("json.load")

--- a/test/unit/test_validate_course.py
+++ b/test/unit/test_validate_course.py
@@ -8,7 +8,6 @@ from validate_course import Course, CourseValidator
 
 @pytest.mark.unit
 class TestCourseValidator:
-
     @mock.patch("validate_course.Path.exists")
     @mock.patch("validate_course.Path.stat")
     def test_model_validation_valid(self, mock_stat, mock_exists):
@@ -28,8 +27,8 @@ class TestCourseValidator:
                     "chapterFileName": "ch1_file.json",
                     "baseFilePath": "ch1.ipynb",
                     "chapterNumber": 1,
-                    "kernelName": "python3",
-                    "kernelId": "python-3",
+                    "kernelName": "qbraid_python",
+                    "kernelId": "qbraid_python",
                     "sections": [],
                 }
             ],

--- a/test/unit/test_validate_dockerfile.py
+++ b/test/unit/test_validate_dockerfile.py
@@ -26,6 +26,7 @@ _join_continuation_lines = vd_module._join_continuation_lines
 _parse_labels = vd_module._parse_labels
 validate_dockerfile = vd_module.validate_dockerfile
 validate_dockerfile_file = vd_module.validate_dockerfile_file
+extract_dockerfile_labels = vd_module.extract_dockerfile_labels
 
 
 VALID_DOCKERFILE = """\
@@ -97,6 +98,10 @@ class TestParseLabels:
         lines = ["FROM python:3.11", "LABEL key=value", "RUN echo hello"]
         labels = _parse_labels(lines)
         assert labels == {"key": "value"}
+
+    def test_extract_dockerfile_labels_from_content(self):
+        labels = extract_dockerfile_labels(VALID_DOCKERFILE)
+        assert labels["qbraid.kernel.name"] == "my_python_kernel"
 
 
 @pytest.mark.unit
@@ -216,6 +221,12 @@ class TestHasKernelJsonCopy:
 
     def test_run_kernelspec(self):
         lines = ["RUN jupyter kernelspec install-self --kernel=kernel.json"]
+        assert _has_kernel_json_copy(lines) is True
+
+    def test_run_ipykernel_install(self):
+        lines = [
+            "RUN python -m ipykernel install --name my_python_kernel --prefix /usr/local"
+        ]
         assert _has_kernel_json_copy(lines) is True
 
     def test_no_kernel_json(self):

--- a/test/unit/test_validate_dockerfile.py
+++ b/test/unit/test_validate_dockerfile.py
@@ -2,7 +2,6 @@
 
 import importlib.util
 from pathlib import Path
-from unittest import mock
 
 import pytest
 

--- a/test/unit/test_validate_dockerfile.py
+++ b/test/unit/test_validate_dockerfile.py
@@ -631,9 +631,7 @@ class TestCheckCopyAddSources:
         assert "a.txt" in errors[0]
 
     def test_url_source_skipped(self):
-        errors = _check_copy_add_sources(
-            ["ADD https://example.com/x.tar /opt/"], set()
-        )
+        errors = _check_copy_add_sources(["ADD https://example.com/x.tar /opt/"], set())
         assert errors == []
 
     def test_var_interpolation_warns_not_fails(self):

--- a/test/unit/test_validate_dockerfile.py
+++ b/test/unit/test_validate_dockerfile.py
@@ -16,6 +16,8 @@ vd_spec.loader.exec_module(vd_module)
 DockerfileValidationResult = vd_module.DockerfileValidationResult
 KERNEL_NAME_PATTERN = vd_module.KERNEL_NAME_PATTERN
 SUPPORTED_LANGUAGES = vd_module.SUPPORTED_LANGUAGES
+_check_copy_add_sources = vd_module._check_copy_add_sources
+_parse_copy_add_sources = vd_module._parse_copy_add_sources
 _get_cmd_or_entrypoint = vd_module._get_cmd_or_entrypoint
 _get_final_user = vd_module._get_final_user
 _has_expose_8888 = vd_module._has_expose_8888
@@ -566,3 +568,116 @@ class TestValidateDockerfileFile:
         with pytest.raises(SystemExit) as exc_info:
             validate_dockerfile_file(str(dockerfile_path))
         assert exc_info.value.code == 1
+
+
+VALID_BASE = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" qbraid.kernel.language="python" qbraid.kernel.display_name="My Kernel"
+COPY kernel.json /usr/local/share/jupyter/kernels/my_kernel/kernel.json
+EXPOSE 8888
+USER 1000
+CMD ["jupyter", "kernelgateway"]
+"""
+
+
+@pytest.mark.unit
+class TestParseCopyAddSources:
+    """Tokenize COPY/ADD source paths."""
+
+    def test_simple_copy(self):
+        assert _parse_copy_add_sources("COPY a.txt /dst/") == ["a.txt"]
+
+    def test_multiple_sources(self):
+        assert _parse_copy_add_sources("COPY a.txt b.txt /dst/") == [
+            "a.txt",
+            "b.txt",
+        ]
+
+    def test_add_directive(self):
+        assert _parse_copy_add_sources("ADD foo.tar.gz /opt/") == ["foo.tar.gz"]
+
+    def test_non_copy_returns_none(self):
+        assert _parse_copy_add_sources("RUN echo hi") is None
+
+    def test_multi_stage_from_skipped(self):
+        assert _parse_copy_add_sources("COPY --from=builder /out /dst/") is None
+
+    def test_chown_chmod_flags_stripped(self):
+        assert _parse_copy_add_sources("COPY --chown=1000:1000 a.txt /dst/") == [
+            "a.txt"
+        ]
+        assert _parse_copy_add_sources("COPY --chmod=755 a.txt /dst/") == ["a.txt"]
+
+    def test_json_array_form(self):
+        assert _parse_copy_add_sources('COPY ["a.txt", "b.txt", "/dst/"]') == [
+            "a.txt",
+            "b.txt",
+        ]
+
+    def test_too_few_args(self):
+        assert _parse_copy_add_sources("COPY a.txt") is None
+
+
+@pytest.mark.unit
+class TestCheckCopyAddSources:
+    """Verify COPY/ADD sources exist in the packaged build context."""
+
+    def test_present_source_passes(self):
+        assert _check_copy_add_sources(["COPY a.txt /dst/"], {"a.txt"}) == []
+
+    def test_missing_source_fails(self):
+        errors = _check_copy_add_sources(["COPY a.txt /dst/"], set())
+        assert len(errors) == 1
+        assert "a.txt" in errors[0]
+
+    def test_url_source_skipped(self):
+        errors = _check_copy_add_sources(
+            ["ADD https://example.com/x.tar /opt/"], set()
+        )
+        assert errors == []
+
+    def test_var_interpolation_warns_not_fails(self):
+        # `$VAR` references can't be resolved statically; we don't fail on them.
+        assert _check_copy_add_sources(["COPY ${VAR}/file /dst/"], set()) == []
+
+    def test_dotslash_prefix_normalized(self):
+        assert _check_copy_add_sources(["COPY ./a.txt /dst/"], {"a.txt"}) == []
+
+    def test_subdir_top_level_check(self):
+        # `COPY src/main.py …` should pass when `src` is in the packaged set.
+        assert _check_copy_add_sources(["COPY src/main.py /dst/"], {"src"}) == []
+        errors = _check_copy_add_sources(["COPY src/main.py /dst/"], set())
+        assert len(errors) == 1
+
+
+@pytest.mark.unit
+class TestValidateDockerfileWithContext:
+    """Integration: validate_dockerfile gates on the context_files set."""
+
+    def test_no_context_files_skips_check(self):
+        # Backwards-compat: if the caller didn't compute a packaged set,
+        # the COPY/ADD presence check doesn't run.
+        content = VALID_BASE + "COPY pyproject.toml /app/\n"
+        result = validate_dockerfile(content, context_files=None)
+        assert result.is_valid
+
+    def test_missing_context_file_reported(self):
+        content = VALID_BASE + "COPY pyproject.toml /app/\n"
+        result = validate_dockerfile(content, context_files={"kernel.json"})
+        assert not result.is_valid
+        assert any("pyproject.toml" in e for e in result.errors)
+
+    def test_present_context_file_passes(self):
+        content = VALID_BASE + "COPY pyproject.toml /app/\n"
+        result = validate_dockerfile(
+            content, context_files={"kernel.json", "pyproject.toml"}
+        )
+        assert result.is_valid
+
+    def test_bloqade_repro(self):
+        """The exact failure that wedged the bloqade build (2026-05-14)."""
+        content = VALID_BASE + "COPY pyproject.toml uv.lock ./\n"
+        result = validate_dockerfile(content, context_files={"kernel.json"})
+        assert not result.is_valid
+        assert any("pyproject.toml" in e for e in result.errors)
+        assert any("uv.lock" in e for e in result.errors)

--- a/test/unit/test_validate_dockerfile.py
+++ b/test/unit/test_validate_dockerfile.py
@@ -1,0 +1,558 @@
+# Copyright (C) 2026 qBraid
+
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SCRIPTS_PATH = PROJECT_ROOT / "src" / "scripts"
+vd_spec = importlib.util.spec_from_file_location(
+    "validate_dockerfile", SCRIPTS_PATH / "validate_dockerfile.py"
+)
+vd_module = importlib.util.module_from_spec(vd_spec)
+vd_spec.loader.exec_module(vd_module)
+
+DockerfileValidationResult = vd_module.DockerfileValidationResult
+KERNEL_NAME_PATTERN = vd_module.KERNEL_NAME_PATTERN
+SUPPORTED_LANGUAGES = vd_module.SUPPORTED_LANGUAGES
+_get_cmd_or_entrypoint = vd_module._get_cmd_or_entrypoint
+_get_final_user = vd_module._get_final_user
+_has_expose_8888 = vd_module._has_expose_8888
+_has_kernel_json_copy = vd_module._has_kernel_json_copy
+_has_privileged_flags = vd_module._has_privileged_flags
+_join_continuation_lines = vd_module._join_continuation_lines
+_parse_labels = vd_module._parse_labels
+validate_dockerfile = vd_module.validate_dockerfile
+validate_dockerfile_file = vd_module.validate_dockerfile_file
+
+
+VALID_DOCKERFILE = """\
+FROM python:3.11-slim
+
+LABEL qbraid.kernel.name="my_python_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Python Kernel"
+
+WORKDIR /app
+
+COPY kernel.json /usr/local/share/jupyter/kernels/my_python_kernel/kernel.json
+
+EXPOSE 8888
+
+CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0", "--KernelGatewayApp.port=8888"]
+"""
+
+
+@pytest.mark.unit
+class TestDockerfileValidationResult:
+    """Tests for DockerfileValidationResult dataclass."""
+
+    def test_empty_result_is_valid(self):
+        result = DockerfileValidationResult()
+        assert result.is_valid is True
+        assert result.errors == []
+
+    def test_add_error_makes_invalid(self):
+        result = DockerfileValidationResult()
+        result.add_error("Test error")
+        assert result.is_valid is False
+        assert len(result.errors) == 1
+        assert result.errors[0] == "Test error"
+
+    def test_multiple_errors(self):
+        result = DockerfileValidationResult()
+        result.add_error("Error 1")
+        result.add_error("Error 2")
+        assert result.is_valid is False
+        assert len(result.errors) == 2
+
+
+@pytest.mark.unit
+class TestParseLabels:
+    """Tests for _parse_labels helper function."""
+
+    def test_parse_single_label(self):
+        lines = ['LABEL key="value"']
+        labels = _parse_labels(lines)
+        assert labels == {"key": "value"}
+
+    def test_parse_multiple_labels_same_line(self):
+        lines = ['LABEL key1="value1" key2="value2"']
+        labels = _parse_labels(lines)
+        assert labels == {"key1": "value1", "key2": "value2"}
+
+    def test_parse_labels_with_backslash_continuation(self):
+        lines = ['LABEL key1="value1" \\', '      key2="value2"']
+        labels = _parse_labels(lines)
+        assert labels.get("key1") == "value1"
+
+    def test_parse_label_without_quotes(self):
+        lines = ["LABEL key=value"]
+        labels = _parse_labels(lines)
+        assert labels == {"key": "value"}
+
+    def test_ignore_non_label_lines(self):
+        lines = ["FROM python:3.11", "LABEL key=value", "RUN echo hello"]
+        labels = _parse_labels(lines)
+        assert labels == {"key": "value"}
+
+
+@pytest.mark.unit
+class TestJoinContinuationLines:
+    """Tests for _join_continuation_lines helper function."""
+
+    def test_join_simple_lines(self):
+        raw_lines = ["line1", "line2", "line3"]
+        result = _join_continuation_lines(raw_lines)
+        assert result == ["line1", "line2", "line3"]
+
+    def test_join_continuation_lines(self):
+        raw_lines = ["line1 \\", "line2 \\", "line3"]
+        result = _join_continuation_lines(raw_lines)
+        assert result == ["line1  line2  line3"]
+
+    def test_skip_comments(self):
+        raw_lines = ["# comment", "line1", "# another comment", "line2"]
+        result = _join_continuation_lines(raw_lines)
+        assert result == ["line1", "line2"]
+
+    def test_handle_empty_content(self):
+        raw_lines = ["", "   ", ""]
+        result = _join_continuation_lines(raw_lines)
+        assert result == []
+
+    def test_trailing_backslash_with_no_next_line(self):
+        raw_lines = ["line1 \\", "line2"]
+        result = _join_continuation_lines(raw_lines)
+        assert result == ["line1  line2"]
+
+
+@pytest.mark.unit
+class TestGetFinalUser:
+    """Tests for _get_final_user helper function."""
+
+    def test_get_user_directive(self):
+        lines = ["FROM python:3.11", "USER root", "USER nobody"]
+        assert _get_final_user(lines) == "nobody"
+
+    def test_no_user_directive(self):
+        lines = ["FROM python:3.11", "RUN pip install something"]
+        assert _get_final_user(lines) is None
+
+    def test_user_case_insensitive(self):
+        lines = ["user ubuntu"]
+        assert _get_final_user(lines) == "ubuntu"
+
+
+@pytest.mark.unit
+class TestHasExpose8888:
+    """Tests for _has_expose_8888 helper function."""
+
+    def test_expose_8888(self):
+        lines = ["EXPOSE 8888"]
+        assert _has_expose_8888(lines) is True
+
+    def test_expose_8888_with_other_ports(self):
+        lines = ["EXPOSE 8080 8888 3000"]
+        assert _has_expose_8888(lines) is True
+
+    def test_expose_8888_tcp(self):
+        lines = ["EXPOSE 8888/tcp"]
+        assert _has_expose_8888(lines) is True
+
+    def test_no_expose_8888(self):
+        lines = ["EXPOSE 8080", "EXPOSE 3000"]
+        assert _has_expose_8888(lines) is False
+
+    def test_case_insensitive(self):
+        lines = ["expose 8888"]
+        assert _has_expose_8888(lines) is True
+
+
+@pytest.mark.unit
+class TestGetCmdOrEntrypoint:
+    """Tests for _get_cmd_or_entrypoint helper function."""
+
+    def test_get_cmd(self):
+        lines = ['CMD ["jupyter", "kernelgateway"]']
+        assert _get_cmd_or_entrypoint(lines) is not None
+        assert "kernelgateway" in _get_cmd_or_entrypoint(lines).lower()
+
+    def test_get_entrypoint(self):
+        lines = ['ENTRYPOINT ["jupyter", "kernelgateway"]']
+        assert _get_cmd_or_entrypoint(lines) is not None
+
+    def test_prefers_last_cmd(self):
+        lines = ['CMD ["echo", "first"]', 'CMD ["jupyter", "kernelgateway"]']
+        result = _get_cmd_or_entrypoint(lines)
+        assert "kernelgateway" in result.lower()
+
+    def test_no_cmd_or_entrypoint(self):
+        lines = ["FROM python:3.11", "RUN pip install something"]
+        assert _get_cmd_or_entrypoint(lines) is None
+
+
+@pytest.mark.unit
+class TestHasKernelJsonCopy:
+    """Tests for _has_kernel_json_copy helper function."""
+
+    def test_copy_kernel_json(self):
+        lines = ["COPY kernel.json /usr/local/share/jupyter/kernels/"]
+        assert _has_kernel_json_copy(lines) is True
+
+    def test_add_kernel_json(self):
+        lines = ["ADD kernel.json /usr/local/share/jupyter/kernels/"]
+        assert _has_kernel_json_copy(lines) is True
+
+    def test_run_echo_kernel_json(self):
+        lines = ['RUN echo \'{"kernel": "spec"}\' > kernel.json']
+        assert _has_kernel_json_copy(lines) is True
+
+    def test_run_cat_kernel_json(self):
+        lines = ["RUN cat > kernel.json << EOF"]
+        assert _has_kernel_json_copy(lines) is True
+
+    def test_run_kernelspec(self):
+        lines = ["RUN jupyter kernelspec install-self --kernel=kernel.json"]
+        assert _has_kernel_json_copy(lines) is True
+
+    def test_no_kernel_json(self):
+        lines = ["COPY requirements.txt /app/", "RUN pip install -r requirements.txt"]
+        assert _has_kernel_json_copy(lines) is False
+
+
+@pytest.mark.unit
+class TestHasPrivilegedFlags:
+    """Tests for _has_privileged_flags helper function."""
+
+    def test_privileged_flag(self):
+        lines = ["docker run --privileged"]
+        assert _has_privileged_flags(lines) is True
+
+    def test_cap_add_sys_admin(self):
+        lines = ["docker run --cap-add=SYS_ADMIN"]
+        assert _has_privileged_flags(lines) is True
+
+    def test_no_privileged_flags(self):
+        lines = ["docker run -p 8888:8888", "docker build -t myimage ."]
+        assert _has_privileged_flags(lines) is False
+
+
+@pytest.mark.unit
+class TestKernelNamePattern:
+    """Tests for KERNEL_NAME_PATTERN regex."""
+
+    def test_valid_kernel_names(self):
+        valid_names = ["python", "my_kernel", "python_3", "abc", "a123bc"]
+        for name in valid_names:
+            assert KERNEL_NAME_PATTERN.match(name), f"Expected {name} to be valid"
+
+    def test_invalid_kernel_names(self):
+        invalid_names = ["", "ab", "Python", "_python", "-python", "has space"]
+        for name in invalid_names:
+            assert not KERNEL_NAME_PATTERN.match(name), f"Expected {name} to be invalid"
+
+    def test_kernel_name_too_long(self):
+        long_name = "a" + "b" * 64
+        assert not KERNEL_NAME_PATTERN.match(long_name)
+
+
+@pytest.mark.unit
+class TestSupportedLanguages:
+    """Tests for SUPPORTED_LANGUAGES constant."""
+
+    def test_expected_languages(self):
+        expected = {"python", "cpp", "julia", "r", "rust", "go", "javascript"}
+        assert SUPPORTED_LANGUAGES == expected
+
+
+@pytest.mark.unit
+class TestValidateDockerfile:
+    """Tests for validate_dockerfile function."""
+
+    def test_valid_dockerfile(self):
+        result = validate_dockerfile(VALID_DOCKERFILE)
+        assert result.is_valid is True
+        assert len(result.errors) == 0
+
+    def test_empty_dockerfile(self):
+        result = validate_dockerfile("")
+        assert result.is_valid is False
+        assert "Dockerfile is empty" in result.errors
+
+    def test_dockerfile_only_comments(self):
+        result = validate_dockerfile("# Comment only\n# Another comment")
+        assert result.is_valid is False
+        assert "no instructions" in result.errors[0]
+
+    def test_missing_required_labels(self):
+        dockerfile = """\
+FROM python:3.11-slim
+EXPOSE 8888
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any("Missing required LABEL" in e for e in result.errors)
+
+    def test_invalid_kernel_name_format(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="Invalid-Name" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="Test"
+EXPOSE 8888
+COPY kernel.json /kernels/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any(
+            "qbraid.kernel.name" in e and "invalid" in e.lower() for e in result.errors
+        )
+
+    def test_unsupported_language(self):
+        dockerfile = """\
+FROM golang:1.21
+LABEL qbraid.kernel.name="my_go_kernel" \\
+      qbraid.kernel.language="cobol" \\
+      qbraid.kernel.display_name="COBOL Kernel"
+EXPOSE 8888
+COPY kernel.json /kernels/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any(
+            "language" in e.lower() and "not supported" in e.lower()
+            for e in result.errors
+        )
+
+    def test_empty_display_name(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name=""
+EXPOSE 8888
+COPY kernel.json /kernels/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any(
+            "display_name" in e.lower() and "empty" in e.lower() for e in result.errors
+        )
+
+    def test_missing_expose_8888(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+COPY kernel.json /kernels/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any("EXPOSE 8888" in e for e in result.errors)
+
+    def test_missing_cmd(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+EXPOSE 8888
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any("CMD or ENTRYPOINT" in e for e in result.errors)
+
+    def test_cmd_without_kernelgateway(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+EXPOSE 8888
+CMD ["python", "-m", "http.server"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any("kernelgateway" in e.lower() for e in result.errors)
+
+    def test_root_user(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+USER root
+EXPOSE 8888
+COPY kernel.json /kernels/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any("root" in e.lower() for e in result.errors)
+
+    def test_privileged_flag(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+EXPOSE 8888
+COPY kernel.json /kernels/
+CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.prespawned_env=foo=--privileged"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any("privileged" in e.lower() for e in result.errors)
+
+    def test_missing_kernel_json(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+EXPOSE 8888
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is False
+        assert any("kernel.json" in e for e in result.errors)
+
+    def test_valid_cpp_dockerfile(self):
+        dockerfile = """\
+FROM gcc:latest
+LABEL qbraid.kernel.name="my_cpp_kernel" \\
+      qbraid.kernel.language="cpp" \\
+      qbraid.kernel.display_name="C++ Kernel"
+EXPOSE 8888
+COPY kernel.json /usr/local/share/jupyter/kernels/my_cpp_kernel/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+    def test_valid_julia_dockerfile(self):
+        dockerfile = """\
+FROM julia:latest
+LABEL qbraid.kernel.name="my_julia_kernel" \\
+      qbraid.kernel.language="julia" \\
+      qbraid.kernel.display_name="Julia Kernel"
+EXPOSE 8888
+COPY kernel.json /usr/local/share/jupyter/kernels/my_julia_kernel/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+    def test_valid_rust_dockerfile(self):
+        dockerfile = """\
+FROM rust:latest
+LABEL qbraid.kernel.name="my_rust_kernel" \\
+      qbraid.kernel.language="rust" \\
+      qbraid.kernel.display_name="Rust Kernel"
+EXPOSE 8888
+COPY kernel.json /usr/local/share/jupyter/kernels/my_rust_kernel/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+    def test_valid_go_dockerfile(self):
+        dockerfile = """\
+FROM golang:latest
+LABEL qbraid.kernel.name="my_go_kernel" \\
+      qbraid.kernel.language="go" \\
+      qbraid.kernel.display_name="Go Kernel"
+EXPOSE 8888
+COPY kernel.json /usr/local/share/jupyter/kernels/my_go_kernel/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+    def test_valid_javascript_dockerfile(self):
+        dockerfile = """\
+FROM node:latest
+LABEL qbraid.kernel.name="my_js_kernel" \\
+      qbraid.kernel.language="javascript" \\
+      qbraid.kernel.display_name="JavaScript Kernel"
+EXPOSE 8888
+COPY kernel.json /usr/local/share/jupyter/kernels/my_js_kernel/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+    def test_valid_r_dockerfile(self):
+        dockerfile = """\
+FROM r-base:latest
+LABEL qbraid.kernel.name="my_r_kernel" \\
+      qbraid.kernel.language="r" \\
+      qbraid.kernel.display_name="R Kernel"
+EXPOSE 8888
+COPY kernel.json /usr/local/share/jupyter/kernels/my_r_kernel/
+CMD ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+    def test_entrypoint_instead_of_cmd(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+EXPOSE 8888
+COPY kernel.json /kernels/
+ENTRYPOINT ["jupyter", "kernelgateway"]
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+    def test_kernel_gateway_underscore_variant(self):
+        dockerfile = """\
+FROM python:3.11-slim
+LABEL qbraid.kernel.name="my_kernel" \\
+      qbraid.kernel.language="python" \\
+      qbraid.kernel.display_name="My Kernel"
+EXPOSE 8888
+COPY kernel.json /kernels/
+CMD jupyter kernel_gateway
+"""
+        result = validate_dockerfile(dockerfile)
+        assert result.is_valid is True
+
+
+@pytest.mark.unit
+class TestValidateDockerfileFile:
+    """Tests for validate_dockerfile_file function."""
+
+    def test_validate_existing_file(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text(VALID_DOCKERFILE)
+
+        try:
+            validate_dockerfile_file(str(dockerfile_path))
+        except SystemExit:
+            pytest.fail("validate_dockerfile_file exited unexpectedly for valid file")
+
+    def test_validate_nonexistent_file(self):
+        with pytest.raises(SystemExit) as exc_info:
+            validate_dockerfile_file("/nonexistent/path/Dockerfile")
+        assert exc_info.value.code == 1
+
+    def test_validate_invalid_file(self, tmp_path):
+        dockerfile_path = tmp_path / "Dockerfile"
+        dockerfile_path.write_text("FROM python:3.11")
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_dockerfile_file(str(dockerfile_path))
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
- Add `deploy-kernel/` composite action for deploying custom Jupyter kernel images to qBraid
- Add `src/scripts/validate_dockerfile.py` for static Dockerfile validation
- Add kernel catalog validation to `validate_course.py` (checks kernelName exists in catalog)

## Usage
Referenced as `qBraid/upload-course-action/deploy-kernel@main` in workflows.

Inputs: `api-key`, `dockerfile-path`, `kernel-name`, `language`, `display-name`, `context-dir`

## Test plan
- [ ] Merge to main
- [ ] Run deploy-kernel workflow from qbraid-tutorial
- [ ] Verify kernel appears in catalog at qbook-staging.k8s.qbraid.com/api/kernelspecs

🤖 Generated with [Claude Code](https://claude.com/claude-code)