### PR TITLE
chore: remove force-duplicate-questions input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,6 @@ The Deploy Course Action is a composite GitHub Action that automates the deploym
 |-------|------|---------|-------------|
 | `course-json-path` | string | `course.json` | Path to course configuration file |
 | `article-type` | string | `course` | Type of article (`course` or `blog`) |
-| `force-duplicate-questions` | string | `false` | Force upload duplicate questions (`true` or `false`) |
 | `draft` | string | `false` | Create draft course (`true` or `false`) |
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ jobs:
 | `repo-read-token` | GitHub token with read access to the repository | **Yes** | N/A |
 | `course-json-path` | Path to `course.json` file | No | `course.json` |
 | `article-type` | Type of article to create (`course` or `blog`) | No | `course` |
-| `force-duplicate-questions` | Whether to force upload duplicate questions (`true` or `false`) | No | `false` |
 | `max-poll-attempts` | Maximum polling attempts before timing out | No | `20` |
 | `poll-interval-seconds` | Seconds to wait between polling attempts | No | `15` |
 | `max-consecutive-errors` | Maximum consecutive polling errors before failing | No | `5` |

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,6 @@ inputs:
     description: 'Type of article (course or blog)'
     required: false
     default: 'course'
-  force-duplicate-questions:
-    description: 'Whether to force duplicate questions'
-    required: false
-    default: 'false'
   draft:
     description: 'Whether to create a draft course (true or false)'
     required: false
@@ -115,8 +111,7 @@ runs:
           --repo-read-token '${{ inputs.repo-read-token }}' \
           --repo-url '${{ github.server_url }}/${{ github.repository }}' \
           --commit-sha '${{ github.sha }}' \
-          --article-type '${{ inputs.article-type }}' \
-          --force-duplicate-questions '${{ inputs.force-duplicate-questions }}'
+          --article-type '${{ inputs.article-type }}'
 
     - name: Stage 5b - Update Course
       if: inputs.mode == 'update'
@@ -129,8 +124,7 @@ runs:
           --repo-read-token '${{ inputs.repo-read-token }}' \
           --repo-url '${{ github.server_url }}/${{ github.repository }}' \
           --commit-sha '${{ github.sha }}' \
-          --article-type '${{ inputs.article-type }}' \
-          --force-duplicate-questions '${{ inputs.force-duplicate-questions }}'
+          --article-type '${{ inputs.article-type }}'
 
     - name: Stage 6 - Poll status end point for completion
       id: poll-status

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -46,9 +46,6 @@ jobs:
 
           # Optional: Type of article to create (course or blog, defaults to 'course')
           article-type: 'course'
-          
-          # Optional: Whether to force upload duplicate questions (defaults to 'false')
-          force-duplicate-questions: 'false'
 
           # Optional: Operation mode ('create' or 'update', defaults to 'create')
           # Can be dynamic based on workflow inputs or variables

--- a/examples/test-workflow-unpublished.yml
+++ b/examples/test-workflow-unpublished.yml
@@ -38,9 +38,6 @@ jobs:
           
           # Optional: Type of article to create (course or blog, defaults to 'course')
           article-type: 'course'
-          
-          # Optional: Whether to force upload duplicate questions (defaults to 'false')
-          force-duplicate-questions: 'false'
 
       - name: Show Results
         if: success()

--- a/examples/workflow.yml
+++ b/examples/workflow.yml
@@ -34,9 +34,6 @@ jobs:
 
           # Optional: Type of article to create (course or blog, defaults to 'course')
           article-type: 'course'
-          
-          # Optional: Whether to force upload duplicate questions (defaults to 'false')
-          force-duplicate-questions: 'false'
 
       - name: Show deployment results
         if: success()

--- a/src/scripts/create_course.py
+++ b/src/scripts/create_course.py
@@ -9,7 +9,6 @@ from deploy_common import (
     CourseDeployer,
     validate_api_key,
     validate_article_type,
-    validate_boolean,
     validate_commit_sha,
     validate_repo_token,
     validate_repo_url,
@@ -28,11 +27,8 @@ class CourseCreator(CourseDeployer):
         repo_url: str,
         commit_sha: str,
         article_type: str = "course",
-        force_duplicate_questions: bool = True,
     ):
-        super().__init__(
-            api_key, repo_read_token, repo_url, commit_sha, force_duplicate_questions
-        )
+        super().__init__(api_key, repo_read_token, repo_url, commit_sha)
         try:
             self.article_type = ArticleType(article_type)
         except ValueError:
@@ -66,7 +62,6 @@ def create_course(
     repo_url: str,
     commit_sha: str,
     article_type: str = "course",
-    force_duplicate_questions: bool = True,
 ):
     """Wrapper for execution."""
     creator = CourseCreator(
@@ -75,7 +70,6 @@ def create_course(
         repo_url,
         commit_sha,
         article_type,
-        force_duplicate_questions,
     )
     try:
         creator.run()
@@ -92,9 +86,6 @@ if __name__ == "__main__":
     parser.add_argument("--repo-url", required=True, type=validate_repo_url)
     parser.add_argument("--commit-sha", required=True, type=validate_commit_sha)
     parser.add_argument("--article-type", required=True, type=validate_article_type)
-    parser.add_argument(
-        "--force-duplicate-questions", required=True, type=validate_boolean
-    )
 
     try:
         args = parser.parse_args()
@@ -104,7 +95,6 @@ if __name__ == "__main__":
             args.repo_url,
             args.commit_sha,
             args.article_type,
-            args.force_duplicate_questions,
         )
     except (ValidationError, argparse.ArgumentError) as e:
         logger.error(f"Validation error: {e}")

--- a/src/scripts/deploy_common.py
+++ b/src/scripts/deploy_common.py
@@ -46,21 +46,6 @@ def validate_article_type(article_type: str) -> str:
     return article_type
 
 
-def validate_boolean(value: str) -> bool:
-    """Validate and convert string to boolean."""
-    if not value:
-        raise ValidationError("Boolean value cannot be empty")
-    value_lower = value.strip().lower()
-    if value_lower in ("true", "1", "yes", "on"):
-        return True
-    elif value_lower in ("false", "0", "no", "off"):
-        return False
-    else:
-        raise ValidationError(
-            f"Invalid boolean value '{value}'. Must be one of: true, false, 1, 0, yes, no, on, off"
-        )
-
-
 def validate_repo_token(token: str) -> str:
     """Validate repository read token is not empty."""
     if not token or not token.strip():
@@ -114,13 +99,11 @@ class CourseDeployer:
         repo_read_token: str,
         repo_url: str,
         commit_sha: str,
-        force_duplicate_questions: bool = True,
     ):
         self.api_key = api_key
         self.repo_read_token = repo_read_token
         self.repo_url = repo_url
         self.commit_sha = commit_sha
-        self.force_duplicate_questions = force_duplicate_questions
         self.session = QbraidSessionV1(api_key=api_key)
         self.session.base_url = Config.API_BASE_URL
 
@@ -144,7 +127,7 @@ class CourseDeployer:
         run_attempt = os.getenv("GITHUB_RUN_ATTEMPT")
         payload = {
             "data": course_data,
-            "forceDuplicateQuestions": self.force_duplicate_questions,
+            "forceDuplicateQuestions": False,
             "repoReadToken": self.repo_read_token,
             "repoUrl": self.repo_url,
             "commitSha": self.commit_sha,

--- a/src/scripts/update_course.py
+++ b/src/scripts/update_course.py
@@ -9,7 +9,6 @@ from deploy_common import (
     CourseDeployer,
     validate_api_key,
     validate_article_type,
-    validate_boolean,
     validate_commit_sha,
     validate_course_id,
     validate_repo_token,
@@ -30,11 +29,8 @@ class CourseUpdater(CourseDeployer):
         repo_url: str,
         commit_sha: str,
         article_type: str = "course",
-        force_duplicate_questions: bool = True,
     ):
-        super().__init__(
-            api_key, repo_read_token, repo_url, commit_sha, force_duplicate_questions
-        )
+        super().__init__(api_key, repo_read_token, repo_url, commit_sha)
         self.course_custom_id = course_custom_id
         try:
             self.article_type = ArticleType(article_type)
@@ -76,7 +72,6 @@ def update_course(
     repo_url: str,
     commit_sha: str,
     article_type: str = "course",
-    force_duplicate_questions: bool = True,
 ):
     """Wrapper for execution."""
     updater = CourseUpdater(
@@ -86,7 +81,6 @@ def update_course(
         repo_url,
         commit_sha,
         article_type,
-        force_duplicate_questions,
     )
     try:
         updater.run()
@@ -104,9 +98,6 @@ if __name__ == "__main__":
     parser.add_argument("--repo-url", required=True, type=validate_repo_url)
     parser.add_argument("--commit-sha", required=True, type=validate_commit_sha)
     parser.add_argument("--article-type", required=True, type=validate_article_type)
-    parser.add_argument(
-        "--force-duplicate-questions", required=True, type=validate_boolean
-    )
 
     try:
         args = parser.parse_args()
@@ -117,7 +108,6 @@ if __name__ == "__main__":
             args.repo_url,
             args.commit_sha,
             args.article_type,
-            args.force_duplicate_questions,
         )
     except (ValidationError, argparse.ArgumentError) as e:
         logger.error(f"Validation error: {e}")

--- a/test/unit/test_create_course.py
+++ b/test/unit/test_create_course.py
@@ -18,7 +18,6 @@ class TestCourseCreator:
         self.creator = CourseCreator(
             api_key=self.api_key,
             article_type="course",
-            force_duplicate_questions=True,
             repo_read_token=self.token,
             repo_url=self.url,
             commit_sha=self.sha,
@@ -45,7 +44,7 @@ class TestCourseCreator:
 
         payload = json.loads(kwargs["data"])
         assert payload["repoReadToken"] == self.token
-        assert payload["forceDuplicateQuestions"] is True
+        assert payload["forceDuplicateQuestions"] is False
         assert kwargs["headers"]["X-API-Key"] == self.api_key
         assert args[0] == "POST"
         assert "/learn/articles/course/ingest" in args[1]
@@ -69,7 +68,7 @@ class TestCourseCreator:
 
         payload = json.loads(kwargs["data"])
         assert payload["repoReadToken"] == self.token
-        assert payload["forceDuplicateQuestions"] is True
+        assert payload["forceDuplicateQuestions"] is False
         assert kwargs["headers"]["X-API-Key"] == self.api_key
         assert args[0] == "POST"
         assert "/learn/articles/course/ingest" in args[1]

--- a/test/unit/test_deploy_common.py
+++ b/test/unit/test_deploy_common.py
@@ -14,7 +14,6 @@ class TestCourseDeployer:
             repo_read_token="token",
             repo_url="https://github.com/qBraid/upload-course-action",
             commit_sha="abc1234",
-            force_duplicate_questions=False,
         )
 
     def test_get_common_payload_includes_integer_run_attempt(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Removes the `force-duplicate-questions` action input and associated plumbing through `create_course.py` / `update_course.py` / `CourseDeployer` so users can no longer opt into uploading duplicate questions.
- Hardcodes `forceDuplicateQuestions: false` in the API payload, ensuring the qBraid API always rejects duplicates regardless of upstream defaults.
- Updates README, AGENTS.md, and example workflows to drop the flag; removes the now-unused `validate_boolean` helper.

## Test plan
- [x] `pytest test/unit/test_deploy_common.py test/unit/test_create_course.py` (12 passed)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)