### PR TITLE
docs: fix imageLink to be repo paths, add chapterFileName

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,14 +91,15 @@ Agents should validate or generate `course.json` with the following structure:
   "courseDescription": "Course description",
   "visibility": "public",
   "imageLink": {
-    "darkLogo": "https://example.com/dark-logo.jpg",
-    "lightLogo": "https://example.com/light-logo.jpg"
+    "darkLogo": "assets/images/dark-logo.png",
+    "lightLogo": "assets/images/light-logo.png"
   },
   "tags": ["tag1", "tag2"],
   "deployedTo": ["qbraid.com"],
   "content": [
     {
       "chapterName": "Chapter Name",
+      "chapterFileName": "notebook.ipynb",
       "chapterNumber": 1,
       "baseFilePath": "./path/to/notebook.ipynb",
       "kernelName": "python3",
@@ -113,6 +114,7 @@ Agents should validate or generate `course.json` with the following structure:
 
 - **Notebooks**: Must exist at paths specified in `course.json`, max 5MB each
 - **Images**: Referenced images must exist and be under 1MB
+- **Logos**: `imageLink.darkLogo` and `imageLink.lightLogo` are repo-relative paths to image files (e.g. `assets/images/dark-logo.png`), not external URLs. Leave as empty strings (`""`) to use the platform default.
 - **Security**: Notebooks are scanned for XSS, script injection, and credential exposure
 
 ## Agent Workflow Steps

--- a/WORKFLOW_GUIDE.md
+++ b/WORKFLOW_GUIDE.md
@@ -24,14 +24,15 @@ Your repository must contain a `course.json` file in the root with the following
   "courseDescription": "A beginner-friendly course on quantum computing fundamentals",
   "visibility": "public",
   "imageLink": {
-    "darkLogo": "https://example.com/dark-logo.jpg",
-    "lightLogo": "https://example.com/light-logo.jpg"
+    "darkLogo": "assets/images/dark-logo.png",
+    "lightLogo": "assets/images/light-logo.png"
   },
   "tags": ["quantum computing", "beginner"],
   "deployedTo": ["qbraid.com"],
   "content": [
     {
       "chapterName": "Introduction to Python",
+      "chapterFileName": "intro.ipynb",
       "chapterNumber": 1,
       "baseFilePath": "./chapter1/intro.ipynb",
       "kernelName": "python3",
@@ -55,9 +56,9 @@ Your repository must contain a `course.json` file in the root with the following
 -   **courseName** (string): Name of the course
 -   **courseDescription** (string): Brief description of the course
 -   **visibility** (string): Visibility setting (e.g., "public", "private")
--   **imageLink** (object): Logo URLs for dark and light themes
-    -   **darkLogo** (string): URL for dark theme logo
-    -   **lightLogo** (string): URL for light theme logo
+-   **imageLink** (object): Logo image paths for dark and light themes
+    -   **darkLogo** (string): Repo-relative path to the dark theme logo image (e.g. `assets/images/dark-logo.png`)
+    -   **lightLogo** (string): Repo-relative path to the light theme logo image (e.g. `assets/images/light-logo.png`)
 -   **tags** (array of strings): List of tags for the course
 -   **deployedTo** (array of strings): Deployment targets (allowed: "qbraid.com", "quera.com")
 -   **content** (array): List of chapters
@@ -65,6 +66,7 @@ Your repository must contain a `course.json` file in the root with the following
 ### Chapter Fields
 
 -   **chapterName** (string): Display name for the chapter
+-   **chapterFileName** (string): Notebook file name for the chapter (e.g. `intro.ipynb`)
 -   **chapterNumber** (number): Chapter number/order
 -   **baseFilePath** (string): Path to the chapter notebook from repo root (max 5MB)
 -   **kernelName** (string): Jupyter kernel to use (e.g., "python3", "qbraid_python")

--- a/examples/course.json
+++ b/examples/course.json
@@ -3,8 +3,8 @@
   "courseDescription": "A beginner-friendly course on the fundamentals of quantum computing, covering qubits, quantum gates, and basic algorithms.",
   "visibility": "public",
   "imageLink": {
-    "darkLogo": "https://img.freepik.com/free-vector/gradient-quantum-illustration_52683-80504.jpg",
-    "lightLogo": "https://img.freepik.com/free-vector/gradient-quantum-illustration_52683-80504.jpg"
+    "darkLogo": "assets/images/dark-logo.png",
+    "lightLogo": "assets/images/light-logo.png"
   },
   "tags": [
     "quantum computing",


### PR DESCRIPTION
## Summary

The `imageLink` documentation described `darkLogo`/`lightLogo` as external URLs, but checking how `course.json` is actually used in the `qBraid-tutorial` repo confirmed they're **repo-relative paths to image files** (e.g. `Current_Quantum_Investors/images/teleportation.png`). The validator treats them as plain strings with no URL validation, so the docs were misleading.

While verifying against real course definitions, I also found that `chapterFileName` is **required** by the validator (`validate_course.py`) and present in every real `course.json`, but was missing from the docs.

## Changes

- **imageLink → paths**
  - `WORKFLOW_GUIDE.md`: example + field descriptions now describe repo-relative image paths instead of URLs.
  - `AGENTS.md`: example updated to paths; added a **Logos** note in File Requirements (repo-relative paths, not URLs; `""` uses the platform default).
  - `examples/course.json`: replaced freepik URLs with `assets/images/{dark,light}-logo.png`.
- **chapterFileName** added to the example and Chapter Fields list in `WORKFLOW_GUIDE.md`, and to the example chapter in `AGENTS.md`.

## Verification

- `examples/course.json` parses as valid JSON.
- `test/unit/test_validate_course.py` — all 4 tests pass.

Docs-only change; no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)